### PR TITLE
chore: Add fmt task

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -2,7 +2,8 @@
 	"tasks": {
 		"dev": "deno run -A --inspect scripts/dev.js",
 		"check": "deno run --allow-env --allow-read npm:typescript@5.0.2/tsc --noEmit -p ./jsconfig.json",
-		"build-gameserver": "deno run -A scripts/buildGameServer.js"
+		"build-gameserver": "deno run -A scripts/buildGameServer.js",
+		"fmt": "deno fmt"
 	},
 	"importMap": "importmap.json",
 	"fmt": {


### PR DESCRIPTION
Running `deno fmt` can format all javascript files on your computer if you're not careful. Adding a task for it means you won't accidentaly do this if you make it a habit to run `deno task fmt` instead of `deno fmt`