### PR TITLE
fix(gs): Players receive invalid skin ids when more than 11 players join with the same skin

### DIFF
--- a/gameServer/src/WebSocketConnection.js
+++ b/gameServer/src/WebSocketConnection.js
@@ -19,7 +19,7 @@ import { Player } from "./gameplay/Player.js";
  * @param {number} colorId
  */
 function serverToClientColorId(colorId) {
-	return colorId - 1;
+	return clamp(colorId - 1, 0, VALID_SKIN_COLOR_RANGE);
 }
 
 /**


### PR DESCRIPTION
Fixes: #28 

The fix was to add a clamp method inside `serverToClientColorId`