### PR TITLE
fix(gs): Player head collision logic

### DIFF
--- a/gameServer/src/gameplay/Player.js
+++ b/gameServer/src/gameplay/Player.js
@@ -641,6 +641,7 @@ export class Player {
 			const includeLastSegments = player != this;
 			if (player.pointIsInTrail(this.#currentPosition, { includeLastSegments })) {
 				const killedSelf = player == this;
+				if (player.dead) continue;
 
 				if (player.isGeneratingTrail || player.#currentDirection == "paused") {
 					const success = this.#killPlayer(player, killedSelf ? "self" : "player");

--- a/gameServer/src/gameplay/Player.js
+++ b/gameServer/src/gameplay/Player.js
@@ -641,16 +641,24 @@ export class Player {
 			const includeLastSegments = player != this;
 			if (player.pointIsInTrail(this.#currentPosition, { includeLastSegments })) {
 				const killedSelf = player == this;
-				const success = this.#killPlayer(player, killedSelf ? "self" : "player");
-				if (success) {
-					this.game.broadcastHitLineAnimation(player, this);
+
+				if (player.isGeneratingTrail || player.#currentDirection == "paused") {
+					const success = this.#killPlayer(player, killedSelf ? "self" : "player");
+					if (success) {
+						this.game.broadcastHitLineAnimation(player, this);
+					}
 				}
+
 				if (
 					!killedSelf &&
 					player.#currentPosition.x == this.#currentPosition.x &&
-					player.#currentPosition.y == this.#currentPosition.y
+					player.#currentPosition.y == this.#currentPosition.y &&
+					this.isGeneratingTrail && player.isGeneratingTrail
 				) {
-					player.#killPlayer(this, "player");
+					const success = player.#killPlayer(this, "player");
+					if (success) {
+						this.game.broadcastHitLineAnimation(this, player);
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Fixes #47
Fixes #59
Fixes not showing hit line animation for both players in a head collision