### PR TITLE
fix(gs): Trails prevent fill

### DIFF
--- a/gameServer/src/gameplay/Game.js
+++ b/gameServer/src/gameplay/Game.js
@@ -326,9 +326,12 @@ export class Game {
 		});
 	}
 
-	*getPlayerPositions() {
+	*getUnfillableLocations() {
 		for (const player of this.#players.values()) {
 			yield player.getPosition();
+			if (player.isGeneratingTrail) {
+				yield Array.from(player.getTrailVertices())[0];
+			}
 		}
 	}
 

--- a/gameServer/src/gameplay/Game.js
+++ b/gameServer/src/gameplay/Game.js
@@ -326,8 +326,18 @@ export class Game {
 		});
 	}
 
-	*getUnfillableLocations() {
+	/**
+	 * Yields a list of player positions,
+	 * and the start of their trail if they have one.
+	 * Used to prevent filling locations with other players inside.
+	 * @param {import("./Player.js").Player} excludePlayer
+	 */
+	*getUnfillableLocations(excludePlayer) {
 		for (const player of this.#players.values()) {
+			if (player == excludePlayer) {
+				continue;
+			}
+
 			yield player.getPosition();
 			if (player.isGeneratingTrail) {
 				yield Array.from(player.getTrailVertices())[0];

--- a/gameServer/src/gameplay/Game.js
+++ b/gameServer/src/gameplay/Game.js
@@ -334,7 +334,7 @@ export class Game {
 	 */
 	*getUnfillableLocations(excludePlayer) {
 		for (const player of this.#players.values()) {
-			if (player == excludePlayer) {
+			if (player == excludePlayer || player.permanentlyDead) {
 				continue;
 			}
 

--- a/gameServer/src/gameplay/Player.js
+++ b/gameServer/src/gameplay/Player.js
@@ -154,6 +154,9 @@ export class Player {
 
 	#permanentlyDead = false;
 	#permanentlyDieTime = 0;
+	get permanentlyDead() {
+		return this.#permanentlyDead;
+	}
 
 	#skinColorId = 0;
 	#skinPatternId = 0;

--- a/gameServer/src/gameplay/Player.js
+++ b/gameServer/src/gameplay/Player.js
@@ -938,7 +938,7 @@ export class Player {
 	async #updateCapturedArea() {
 		const totalFilledTileCount = await this.game.arena.updateCapturedArea(
 			this.id,
-			Array.from(this.game.getPlayerPositions()),
+			Array.from(this.game.getUnfillableLocations()),
 		);
 		if (this.#capturedTileCount != totalFilledTileCount) {
 			this.#capturedTileCount = totalFilledTileCount;

--- a/gameServer/src/gameplay/Player.js
+++ b/gameServer/src/gameplay/Player.js
@@ -938,7 +938,7 @@ export class Player {
 	async #updateCapturedArea() {
 		const totalFilledTileCount = await this.game.arena.updateCapturedArea(
 			this.id,
-			Array.from(this.game.getUnfillableLocations()),
+			Array.from(this.game.getUnfillableLocations(this)),
 		);
 		if (this.#capturedTileCount != totalFilledTileCount) {
 			this.#capturedTileCount = totalFilledTileCount;

--- a/gameServer/src/gameplay/arenaWorker/updateCapturedArea.js
+++ b/gameServer/src/gameplay/arenaWorker/updateCapturedArea.js
@@ -77,7 +77,12 @@ export function updateCapturedArea(arenaTiles, playerId, bounds, otherPlayerLoca
 	// Since we don't want players to just fill a large area around another player.
 	for (const location of otherPlayerLocations) {
 		const pos = new Vec2(location);
-		nodes.push(pos);
+		nodes.push(
+			pos.clone().add(0, 1),
+			pos.clone().add(0, -1),
+			pos.clone().add(1, 0),
+			pos.clone().add(-1, 0),
+		);
 		// We don't need to do a `testFillNode` assertion for these seeds.
 		// There are actually good reasons why player positions might not be valid nodes.
 		// They could lie outside the bounds for instance, or maybe this player is currently inside the

--- a/gameServer/src/gameplay/arenaWorker/updateCapturedArea.js
+++ b/gameServer/src/gameplay/arenaWorker/updateCapturedArea.js
@@ -87,8 +87,6 @@ export function updateCapturedArea(arenaTiles, playerId, bounds, unfillableLocat
 		// There are actually good reasons why player positions might not be valid nodes.
 		// They could lie outside the bounds for instance, or maybe this player is currently inside the
 		// captured area of the other player.
-		// `unfillableLocations` will also contain the location of the player that is currently filling this area itself,
-		// so this check should exclude the players own location as well.
 	}
 
 	while (true) {

--- a/gameServer/src/gameplay/arenaWorker/updateCapturedArea.js
+++ b/gameServer/src/gameplay/arenaWorker/updateCapturedArea.js
@@ -30,9 +30,9 @@ export function initializeMask(width, height) {
  * @param {number[][]} arenaTiles
  * @param {number} playerId
  * @param {import("../../util/util.js").Rect} bounds
- * @param {[x: number, y: number][]} otherPlayerLocations
+ * @param {[x: number, y: number][]} unfillableLocations
  */
-export function updateCapturedArea(arenaTiles, playerId, bounds, otherPlayerLocations) {
+export function updateCapturedArea(arenaTiles, playerId, bounds, unfillableLocations) {
 	// We'll want to add padding of 1 tile to each edge of the bounds.
 	// The reason for this is that we want to seed the flood fill algorithm at the top left corner of the bounds.
 	// We need to have at least one tile around the area that is not owned by the player that we try to fill for.
@@ -75,7 +75,7 @@ export function updateCapturedArea(arenaTiles, playerId, bounds, otherPlayerLoca
 
 	// We also add seeds for all the player positions in the game,
 	// Since we don't want players to just fill a large area around another player.
-	for (const location of otherPlayerLocations) {
+	for (const location of unfillableLocations) {
 		const pos = new Vec2(location);
 		nodes.push(
 			pos.clone().add(0, 1),
@@ -87,7 +87,7 @@ export function updateCapturedArea(arenaTiles, playerId, bounds, otherPlayerLoca
 		// There are actually good reasons why player positions might not be valid nodes.
 		// They could lie outside the bounds for instance, or maybe this player is currently inside the
 		// captured area of the other player.
-		// `otherPlayerLocations` will also contain the location of the player that is currently filling this area itself,
+		// `unfillableLocations` will also contain the location of the player that is currently filling this area itself,
 		// so this check should exclude the players own location as well.
 	}
 


### PR DESCRIPTION
Make start of trails also prevent fill, so that someone completely surrounded by an enemy will not have their blocks disappear when they exit their land
Make the 4 tiles around the pos prevent fill instead of the same pos itself, for trail start fix to work and to allow taking the block underneath a paused player
Related: #3