### PR TITLE
fix(client,admin): Include hash in generated javascript bundle filenames

### DIFF
--- a/adminPanel/index.html
+++ b/adminPanel/index.html
@@ -12,6 +12,6 @@
 			</script>
 		</head>
 	<body>
-		<script src="src/main.js" type="module"></script>
+		<script src="./src/main.js" type="module"></script>
 	</body>
 </html>

--- a/scripts/buildAdminPanel.js
+++ b/scripts/buildAdminPanel.js
@@ -38,7 +38,7 @@ const bundle = await rollup({
 		}),
 	],
 });
-const {output} = await bundle.write({
+const { output } = await bundle.write({
 	dir: path.resolve(distDir, "bundle"),
 	format: "esm",
 	entryFileNames: "[name]-[hash].js",

--- a/scripts/buildClient.js
+++ b/scripts/buildClient.js
@@ -40,7 +40,7 @@ const bundle = await rollup({
 		}),
 	],
 });
-const {output} = await bundle.write({
+const { output } = await bundle.write({
 	dir: resolve(distDir, "bundle"),
 	format: "esm",
 	entryFileNames: "[name]-[hash].js",


### PR DESCRIPTION
Some people were having trouble connecting. Presumably because they had a cached `main.js` file which was still pointing to an old gameservers endpoint.

This PR lets rollup include the hash in the filename of the main entry point, which is then updated in the index.html file.
That way a request to a new path is made every time the client updates. Both the local cache and the cloudflare cache should be ignored that way.