### PR TITLE
chore: Use jsdelivr instead of unpkg for fetching types

### DIFF
--- a/scripts/dev.js
+++ b/scripts/dev.js
@@ -34,10 +34,10 @@ generateTypes({
 		"rollup",
 	],
 	exactTypeModules: {
-		"$rollup": "https://unpkg.com/rollup@3.5.0/dist/rollup.d.ts",
-		"$rollup-plugin-alias": "https://unpkg.com/@rollup/plugin-alias@4.0.2/types/index.d.ts",
+		"$rollup": "https://cdn.jsdelivr.net/npm/rollup@3.5.0/dist/rollup.d.ts",
+		"$rollup-plugin-alias": "https://cdn.jsdelivr.net/npm/@rollup/plugin-alias@4.0.2/types/index.d.ts",
 		"$rollup-plugin-replace": "https://cdn.jsdelivr.net/npm/@rollup/plugin-replace@5.0.4/types/index.d.ts",
-		"$terser": "https://unpkg.com/terser@5.16.0/tools/terser.d.ts",
+		"$terser": "https://cdn.jsdelivr.net/npm/terser@5.16.0/tools/terser.d.ts",
 	},
 	logLevel: "WARNING",
 });


### PR DESCRIPTION
ci is frequently running into 502 errors when fetching these requests.
Only thing I could find was
https://github.com/mjackson/unpkg/issues/330