### PR TITLE
fix(gs): Catch more trail assertion errors

### DIFF
--- a/gameServer/src/gameplay/Player.js
+++ b/gameServer/src/gameplay/Player.js
@@ -591,12 +591,12 @@ export class Player {
 
 				try {
 					this.#updateCurrentTile(previousPosition);
+					this.#currentPositionChanged();
+					this.#drainMovementQueue();
 				} catch (e) {
 					console.error(e);
 					this.#connection.close();
 				}
-				this.#currentPositionChanged();
-				this.#drainMovementQueue();
 			}
 		}
 


### PR DESCRIPTION
Another attempt at fixing #43.
`#drainMovementQueue()` calls `#addTrailVertex()` as well, so it should be moved into the try catch block too.