### PR TITLE
chore: Downgrade rollup

### DIFF
--- a/importmap.json
+++ b/importmap.json
@@ -3,7 +3,7 @@
 		"$std/": "https://deno.land/std@0.198.0/",
 		"renda": "https://raw.githubusercontent.com/rendajs/Renda/5722ef6433ed217715bb4ef0ab2bbd6a96b3992d/mod.js",
 		"chdir-anywhere": "https://deno.land/x/chdir_anywhere@v0.0.3/mod.js",
-		"$rollup": "npm:rollup@4.1.5",
+		"$rollup": "npm:rollup@3.20.2",
 		"$rollup-plugin-replace": "npm:@rollup/plugin-replace@5.0.4",
 		"$rollup-plugin-alias": "npm:@rollup/plugin-alias@4.0.2",
 		"$terser": "npm:terser@5.15.0"


### PR DESCRIPTION
Not sure why the release script is failing.
It works fine locally.
I'm guessing the recent rollup upgrade causes this, because the error happens in `npm:rollup@4.1.5/dist/native.js`
See: https://cdn.jsdelivr.net/npm/rollup@4.1.5/dist/native.js

I think Deno might not have polyfilled getReport()

<img width="921" alt="image" src="https://github.com/jespertheend/splix/assets/2737650/4a6a7ebc-4e7a-4f8e-bd26-1f7f26beb3b5">
