### PR TITLE
fix(gs): Return unfilled tile types for nonexistent players

### DIFF
--- a/gameServer/src/gameplay/Game.js
+++ b/gameServer/src/gameplay/Game.js
@@ -245,7 +245,10 @@ export class Game {
 
 		const tilePlayer = this.#players.get(tileValue);
 		if (!tilePlayer) {
-			throw new Error("Assertion failed, the tile points to a non existent player");
+			return {
+				colorId: 1, // unfilled/grey
+				patternId: 0,
+			};
 		}
 
 		const colorId = tilePlayer.skinColorIdForPlayer(player) + 1;


### PR DESCRIPTION
Potential fix for #122

It seems like tile values that point to non existent players is intentional, so we shouldn't throw an assertion error.
Unfortunately this also means that if there is ever a bug causing tiles from disconnected players to not get cleaned up, we will never find out. But that's a trade off I'm willing to make.