### PR TITLE
fix(gs): Prevent duplicate minimap parts and use SinglePromiseInstance

### DIFF
--- a/gameServer/src/gameplay/Game.js
+++ b/gameServer/src/gameplay/Game.js
@@ -1,6 +1,6 @@
 /** @typedef {"default" | "teams"} GameModes */
 
-import { lerp, Vec2 } from "renda";
+import { lerp, SingleInstancePromise, Vec2 } from "renda";
 import { Arena } from "./Arena.js";
 import { Player } from "./Player.js";
 import { WebSocketConnection } from "../WebSocketConnection.js";
@@ -26,6 +26,7 @@ export class Game {
 
 	/** @type {ArrayBuffer[]} */
 	#minimapMessages = [];
+	#updateNextMinimapPartInstance;
 	#lastMinimapUpdateTime = 0;
 	#lastMinimapPart = 0;
 	#lastLeaderboardSendTime = 0;
@@ -53,6 +54,8 @@ export class Game {
 				player.connection.sendFillRect(rect, colorId, patternId);
 			}
 		});
+
+		this.#updateNextMinimapPartInstance = new SingleInstancePromise(this.#updateNextMinimapPart);
 	}
 
 	/**
@@ -66,7 +69,7 @@ export class Game {
 
 		if (now - this.#lastMinimapUpdateTime > MINIMAP_PART_UPDATE_FREQUENCY) {
 			this.#lastMinimapUpdateTime = now;
-			this.#updateNextMinimapPart();
+			this.#updateNextMinimapPartInstance.run();
 		}
 
 		if (now - this.#lastLeaderboardSendTime > LEADERBOARD_UPDATE_FREQUENCY) {
@@ -258,7 +261,7 @@ export class Game {
 		};
 	}
 
-	async #updateNextMinimapPart() {
+	#updateNextMinimapPart = async () => {
 		this.#lastMinimapPart = (this.#lastMinimapPart + 1) % 4;
 		const lastMinimapPart = this.#lastMinimapPart;
 		const part = await this.#arena.getMinimapPart(lastMinimapPart);
@@ -267,7 +270,7 @@ export class Game {
 		for (const player of this.#players.values()) {
 			player.connection.send(message);
 		}
-	}
+	};
 
 	*getMinimapMessages() {
 		yield* this.#minimapMessages;

--- a/gameServer/src/gameplay/Game.js
+++ b/gameServer/src/gameplay/Game.js
@@ -55,7 +55,7 @@ export class Game {
 			}
 		});
 
-		this.#updateNextMinimapPartInstance = new SingleInstancePromise(this.#updateNextMinimapPart);
+		this.#updateNextMinimapPartInstance = new SingleInstancePromise(() => this.#updateNextMinimapPart());
 	}
 
 	/**
@@ -261,7 +261,7 @@ export class Game {
 		};
 	}
 
-	#updateNextMinimapPart = async () => {
+	async #updateNextMinimapPart() {
 		this.#lastMinimapPart = (this.#lastMinimapPart + 1) % 4;
 		const lastMinimapPart = this.#lastMinimapPart;
 		const part = await this.#arena.getMinimapPart(lastMinimapPart);
@@ -270,7 +270,7 @@ export class Game {
 		for (const player of this.#players.values()) {
 			player.connection.send(message);
 		}
-	};
+	}
 
 	*getMinimapMessages() {
 		yield* this.#minimapMessages;

--- a/gameServer/src/gameplay/Game.js
+++ b/gameServer/src/gameplay/Game.js
@@ -259,11 +259,11 @@ export class Game {
 	}
 
 	async #updateNextMinimapPart() {
-		this.#lastMinimapPart++;
-		this.#lastMinimapPart = this.#lastMinimapPart % 4;
-		const part = await this.#arena.getMinimapPart(this.#lastMinimapPart);
-		const message = WebSocketConnection.createMinimapMessage(this.#lastMinimapPart, part);
-		this.#minimapMessages[this.#lastMinimapPart] = message;
+		this.#lastMinimapPart = (this.#lastMinimapPart + 1) % 4;
+		const lastMinimapPart = this.#lastMinimapPart;
+		const part = await this.#arena.getMinimapPart(lastMinimapPart);
+		const message = WebSocketConnection.createMinimapMessage(lastMinimapPart, part);
+		this.#minimapMessages[lastMinimapPart] = message;
 		for (const player of this.#players.values()) {
 			player.connection.send(message);
 		}


### PR DESCRIPTION
Prevent minimap parts appearing as duplicates or in the wrong place, this happens when the server or arena worker hangs long enough for more parts to be requested before the earlier one finished awaiting.
Fixes #130