### PR TITLE
feat(gs, client): Don't animate tiles when sending edge chunks

### DIFF
--- a/client/src/main.js
+++ b/client/src/main.js
@@ -1720,8 +1720,9 @@ function onMessage(evt) {
 		w = bytesToInt(data[5], data[6]);
 		h = bytesToInt(data[7], data[8]);
 		type = data[9];
-		var pattern = data[10];
-		fillArea(x, y, w, h, type, pattern);
+		const pattern = data[10];
+		const isEdgeChunk = data[11];
+		fillArea(x, y, w, h, type, pattern, undefined, isEdgeChunk);
 	}
 	if (data[0] == receiveAction.SET_TRAIL) {
 		id = bytesToInt(data[1], data[2]);
@@ -3276,7 +3277,7 @@ function orderTwoPos(pos1, pos2) {
 }
 
 //fills an area, if array is not specified it defaults to blocks[]
-function fillArea(x, y, w, h, type, pattern, array) {
+function fillArea(x, y, w, h, type, pattern, array, isEdgeChunk = false) {
 	var defaultArray = array === undefined;
 	if (defaultArray) {
 		array = blocks;
@@ -3299,7 +3300,7 @@ function fillArea(x, y, w, h, type, pattern, array) {
 		for (var j = y; j < y2; j++) {
 			var block = getBlock(i, j, array);
 			var thisType = applyPattern(type, pattern, i, j);
-			block.setBlockId(thisType, Math.random() * 400);
+			block.setBlockId(thisType, isEdgeChunk ? false : Math.random() * 400);
 		}
 	}
 }

--- a/gameServer/src/WebSocketConnection.js
+++ b/gameServer/src/WebSocketConnection.js
@@ -479,9 +479,10 @@ export class WebSocketConnection {
 	 * @param {import("./util/util.js").Rect} rect
 	 * @param {number} tileType
 	 * @param {number} patternId
+	 * @param {boolean} isEdgeChunk
 	 */
-	sendFillRect(rect, tileType, patternId) {
-		const buffer = new ArrayBuffer(11);
+	sendFillRect(rect, tileType, patternId, isEdgeChunk = false) {
+		const buffer = new ArrayBuffer(12);
 		const view = new DataView(buffer);
 		let cursor = 0;
 
@@ -506,6 +507,9 @@ export class WebSocketConnection {
 		cursor++;
 
 		view.setUint8(cursor, patternId);
+		cursor++;
+
+		view.setUint8(cursor, isEdgeChunk ? 1 : 0);
 		cursor++;
 
 		this.send(buffer);

--- a/gameServer/src/gameplay/Player.js
+++ b/gameServer/src/gameplay/Player.js
@@ -833,7 +833,7 @@ export class Player {
 	sendChunk(rect) {
 		const chunkData = this.game.getArenaChunkForMessage(rect, this);
 		for (const rect of chunkData) {
-			this.connection.sendFillRect(rect.rect, rect.tileType.colorId, rect.tileType.patternId);
+			this.connection.sendFillRect(rect.rect, rect.tileType.colorId, rect.tileType.patternId, true);
 		}
 	}
 


### PR DESCRIPTION
fixes #87 

I followed the additional bit approach.