### PR TITLE
fix(gs): Update scores when someone steals some of your tiles

### DIFF
--- a/gameServer/src/gameplay/Game.js
+++ b/gameServer/src/gameplay/Game.js
@@ -527,4 +527,16 @@ export class Game {
 			nearbyPlayer.connection.send(message);
 		}
 	}
+
+	/**
+	 * Updates the scores of all players except the current player.
+	 * @param {import("./Player.js").Player} currentPlayer
+	 */
+	updatePlayerScores(currentPlayer) {
+		for (const player of this.#players.values()) {
+			if (player == currentPlayer) continue;
+			if (player.isGeneratingTrail && player.currentDirection !== "paused") continue;
+			player.updateCapturedArea();
+		}
+	}
 }

--- a/gameServer/src/gameplay/Player.js
+++ b/gameServer/src/gameplay/Player.js
@@ -1003,7 +1003,7 @@ export class Player {
 					throw new Error("Assertion failed, player tiles have already been removed from the arena.");
 				}
 				this.game.arena.fillPlayerTrail(this.#trailVertices, this.id);
-				this.#updateCapturedArea();
+				this.updateCapturedArea();
 				this.game.broadcastPlayerEmptyTrail(this);
 				this.#clearTrailVertices();
 			}
@@ -1012,7 +1012,7 @@ export class Player {
 		}
 	}
 
-	async #updateCapturedArea() {
+	async updateCapturedArea() {
 		const totalFilledTileCount = await this.game.arena.updateCapturedArea(
 			this.id,
 			Array.from(this.game.getUnfillableLocations(this)),
@@ -1028,6 +1028,7 @@ export class Player {
 			this.#capturedTileCount = capturedTileCount;
 			this.#maxCapturedTileCount = Math.max(this.#maxCapturedTileCount, this.#capturedTileCount);
 			this.#sendMyScore();
+			this.game.updatePlayerScores(this);
 		}
 	}
 


### PR DESCRIPTION
Fixes #135 

I've left a case when player is still moving (have `trailVertices`) as in this case player will either die or capture their block which will update their scores. 