### PR TITLE
feat(gs): Ratelimit messages through websockets 

### DIFF
--- a/gameServer/src/WebSocketManager.js
+++ b/gameServer/src/WebSocketManager.js
@@ -2,7 +2,7 @@ import { RateLimitManager } from "../../shared/RateLimitManager.js";
 import { WebSocketConnection } from "./WebSocketConnection.js";
 import { getMainInstance } from "./mainInstance.js";
 import { WebSocketHoster } from "./util/WebSocketHoster.js";
-import { DinoRateLimiter } from "./util/SocketRateLimiter.js";
+import { SocketRateLimiter } from "./util/SocketRateLimiter.js";
 
 export class WebSocketManager {
 	#hoster;
@@ -28,7 +28,7 @@ export class WebSocketManager {
 			const connection = new WebSocketConnection(socket, ip, getMainInstance().game);
 			this.#activeConnections.add(connection);
 
-			const socketRateLimiter = new DinoRateLimiter({
+			const socketRateLimiter = new SocketRateLimiter({
 				maxMessages: 20,
 				interval: 100,
 				onRateLimitExceeded: () => {

--- a/gameServer/src/WebSocketManager.js
+++ b/gameServer/src/WebSocketManager.js
@@ -33,7 +33,7 @@ export class WebSocketManager {
 				interval: 100,
 				onRateLimitExceeded: () => {
 					socket.close();
-				}
+				},
 			});
 
 			socket.addEventListener("message", async (message) => {

--- a/gameServer/src/util/SocketRateLimiter.js
+++ b/gameServer/src/util/SocketRateLimiter.js
@@ -1,7 +1,7 @@
 /**
  * Limit the number of messages sent to the server within a time interval
  * to guard against socket abuse.
- * 
+ *
  * @example
  * const rateLimiter = new DinoRateLimiter({
  *    maxMessages: 20, // Allow a maximum of 20 messages
@@ -10,7 +10,7 @@
  *        socket.close(); // close the connection when limit is exceeded
  *    }
  * });
- * 
+ *
  * // Trigger the tick() method when a message is received
  * if (rateLimiter.tick()) {
  *    console.log('Rate limit exceeded');
@@ -20,47 +20,47 @@
  */
 
 export class DinoRateLimiter {
-    /**
-     * @param {Object} options - Configurations
-     * @param {number} options.maxMessages - Maximum number of messages allowed in the time interval.
-     * @param {number} options.interval - Time interval in milliseconds for the rate limit.
-     * @param {Function} [options.onRateLimitExceeded] - Optional callback to invoke when the rate limit is exceeded.
-     */
-    constructor({ maxMessages, interval, onRateLimitExceeded = undefined }) {
-        /** @type {number[]} */
-        this.messageTimeQueue = [];
-        this.maxMessages = maxMessages;
-        this.interval = interval;
-        this.onRateLimitExceeded = onRateLimitExceeded;
-    }
+	/**
+	 * @param {Object} options - Configurations
+	 * @param {number} options.maxMessages - Maximum number of messages allowed in the time interval.
+	 * @param {number} options.interval - Time interval in milliseconds for the rate limit.
+	 * @param {Function} [options.onRateLimitExceeded] - Optional callback to invoke when the rate limit is exceeded.
+	 */
+	constructor({ maxMessages, interval, onRateLimitExceeded = undefined }) {
+		/** @type {number[]} */
+		this.messageTimeQueue = [];
+		this.maxMessages = maxMessages;
+		this.interval = interval;
+		this.onRateLimitExceeded = onRateLimitExceeded;
+	}
 
-    /**
-     * Checks if the rate limit is exceeded and pushes the message timestamp to the 
-     * message queue. This method must be called every time a message is received. 
-     * If the rate limit is reached, it executes the `onRateLimitExceeded` callback.
-     *
-     * @returns {boolean} - Returns true if the rate limit is exceeded, otherwise false.
-     * 
-     * @callback onRateLimitExceeded
-     * @description Callback function that is executed when the rate limit is exceeded.
-     */
-    tick() {
-        const now = Date.now();
-        this.messageTimeQueue.push(now);
+	/**
+	 * Checks if the rate limit is exceeded and pushes the message timestamp to the
+	 * message queue. This method must be called every time a message is received.
+	 * If the rate limit is reached, it executes the `onRateLimitExceeded` callback.
+	 *
+	 * @returns {boolean} - Returns true if the rate limit is exceeded, otherwise false.
+	 *
+	 * @callback onRateLimitExceeded
+	 * @description Callback function that is executed when the rate limit is exceeded.
+	 */
+	tick() {
+		const now = Date.now();
+		this.messageTimeQueue.push(now);
 
-        // remove old message timestamps
-        while (this.messageTimeQueue.length > 0 && now - this.messageTimeQueue[0] > this.interval) {
-            this.messageTimeQueue.shift();
-        }
+		// remove old message timestamps
+		while (this.messageTimeQueue.length > 0 && now - this.messageTimeQueue[0] > this.interval) {
+			this.messageTimeQueue.shift();
+		}
 
-        // console.log(this.messageTimeQueue.length); // DEBUG
+		// console.log(this.messageTimeQueue.length); // DEBUG
 
-        if (this.messageTimeQueue.length > this.maxMessages) {
-            if (this.onRateLimitExceeded) {
-                this.onRateLimitExceeded();
-            }
-            return true;
-        }
-        return false;
-    }
+		if (this.messageTimeQueue.length > this.maxMessages) {
+			if (this.onRateLimitExceeded) {
+				this.onRateLimitExceeded();
+			}
+			return true;
+		}
+		return false;
+	}
 }

--- a/gameServer/src/util/SocketRateLimiter.js
+++ b/gameServer/src/util/SocketRateLimiter.js
@@ -19,7 +19,13 @@
  * }
  */
 
-export class DinoRateLimiter {
+export class SocketRateLimiter {
+	/** @type {number[]} */
+	#messageTimeQueue = [];
+	#maxMessages;
+	#interval;
+	#onRateLimitExceeded;
+
 	/**
 	 * @param {Object} options - Configurations
 	 * @param {number} options.maxMessages - Maximum number of messages allowed in the time interval.
@@ -27,11 +33,9 @@ export class DinoRateLimiter {
 	 * @param {Function} [options.onRateLimitExceeded] - Optional callback to invoke when the rate limit is exceeded.
 	 */
 	constructor({ maxMessages, interval, onRateLimitExceeded = undefined }) {
-		/** @type {number[]} */
-		this.messageTimeQueue = [];
-		this.maxMessages = maxMessages;
-		this.interval = interval;
-		this.onRateLimitExceeded = onRateLimitExceeded;
+		this.#maxMessages = maxMessages;
+		this.#interval = interval;
+		this.#onRateLimitExceeded = onRateLimitExceeded;
 	}
 
 	/**
@@ -40,24 +44,21 @@ export class DinoRateLimiter {
 	 * If the rate limit is reached, it executes the `onRateLimitExceeded` callback.
 	 *
 	 * @returns {boolean} - Returns true if the rate limit is exceeded, otherwise false.
-	 *
-	 * @callback onRateLimitExceeded
-	 * @description Callback function that is executed when the rate limit is exceeded.
 	 */
 	tick() {
 		const now = Date.now();
-		this.messageTimeQueue.push(now);
+		this.#messageTimeQueue.push(now);
 
 		// remove old message timestamps
-		while (this.messageTimeQueue.length > 0 && now - this.messageTimeQueue[0] > this.interval) {
-			this.messageTimeQueue.shift();
+		while (this.#messageTimeQueue.length > 0 && now - this.#messageTimeQueue[0] > this.#interval) {
+			this.#messageTimeQueue.shift();
 		}
 
 		// console.log(this.messageTimeQueue.length); // DEBUG
 
-		if (this.messageTimeQueue.length > this.maxMessages) {
-			if (this.onRateLimitExceeded) {
-				this.onRateLimitExceeded();
+		if (this.#messageTimeQueue.length > this.#maxMessages) {
+			if (this.#onRateLimitExceeded) {
+				this.#onRateLimitExceeded();
 			}
 			return true;
 		}

--- a/gameServer/src/util/SocketRateLimiter.js
+++ b/gameServer/src/util/SocketRateLimiter.js
@@ -1,0 +1,65 @@
+/**
+ * Limit the number of messages sent to the server within a time interval
+ * to guard against socket abuse.
+ * 
+ * @example
+ * const rateLimiter = new DinoRateLimiter({
+ *    maxMessages: 20, // Allow a maximum of 20 messages
+ *    interval: 100, // Within a 100ms time window
+ *    onRateLimitExceeded: () => {
+ *        socket.close(); // close the connection when limit is exceeded
+ *    }
+ * });
+ * 
+ * // Trigger the tick() method when a message is received
+ * if (rateLimiter.tick()) {
+ *    console.log('Rate limit exceeded');
+ * } else {
+ *    console.log('Message received');
+ * }
+ */
+
+export class DinoRateLimiter {
+    /**
+     * @param {Object} options - Configurations
+     * @param {number} options.maxMessages - Maximum number of messages allowed in the time interval.
+     * @param {number} options.interval - Time interval in milliseconds for the rate limit.
+     * @param {Function} [options.onRateLimitExceeded] - Optional callback to invoke when the rate limit is exceeded.
+     */
+    constructor({ maxMessages, interval, onRateLimitExceeded = undefined }) {
+        /** @type {number[]} */
+        this.messageTimeQueue = [];
+        this.maxMessages = maxMessages;
+        this.interval = interval;
+        this.onRateLimitExceeded = onRateLimitExceeded;
+    }
+
+    /**
+     * Checks if the rate limit is exceeded and pushes the message timestamp to the 
+     * message queue. This method must be called every time a message is received. 
+     * If the rate limit is reached, it executes the `onRateLimitExceeded` callback.
+     *
+     * @returns {boolean} - Returns true if the rate limit is exceeded, otherwise false.
+     * 
+     * @callback onRateLimitExceeded
+     * @description Callback function that is executed when the rate limit is exceeded.
+     */
+    tick() {
+        const now = Date.now();
+        this.messageTimeQueue.push(now);
+
+        // remove old message timestamps
+        while (this.messageTimeQueue.length > 0 && now - this.messageTimeQueue[0] > this.interval) {
+            this.messageTimeQueue.shift();
+        }
+
+        // console.log(this.messageTimeQueue.length); // DEBUG
+
+        if (this.messageTimeQueue.length > this.maxMessages && this.onRateLimitExceeded) {
+            this.onRateLimitExceeded();
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/gameServer/src/util/SocketRateLimiter.js
+++ b/gameServer/src/util/SocketRateLimiter.js
@@ -55,11 +55,12 @@ export class DinoRateLimiter {
 
         // console.log(this.messageTimeQueue.length); // DEBUG
 
-        if (this.messageTimeQueue.length > this.maxMessages && this.onRateLimitExceeded) {
-            this.onRateLimitExceeded();
+        if (this.messageTimeQueue.length > this.maxMessages) {
+            if (this.onRateLimitExceeded) {
+                this.onRateLimitExceeded();
+            }
             return true;
         }
-
         return false;
     }
 }


### PR DESCRIPTION
Fixes #152

Prevents DoS abuse by limiting the number of messages sent through a websocket within a specified time interval. The connection is terminated if this limit is exceeded.

### Configuration:
**Rate Limit:** 20 messages per 100ms. 

### Testing:
1. High-frequency Inputs:
       Local testing (e.g., spamming arrow keys manually and programmatically) showed an average of 0.3 messages per 100ms and a maximum of 9 messages during instance initiation.
2. Chat Testing:
        Messages sent through `wrong chat` triggered a maximum of 3 messages per 100ms.
3. Simulated Latency:
        Results were consistent across latency values of [0, 600]. The maximum has been reduced to 6 messages per 100ms on high ping environments.
4.  Scale Testing:
        Tested with up to 6 users. Results were consistent, but further testing in a larger user environment is required to confirm scalability.

### Future Improvements:
- Implementing a temporary ban for frequent abusers.
- Enqueue messages exceeding the limit with a timeout, causing offenders to experience lag without impacting the gameplay of others.

### Notes:
The implementation has shown promising results in controlled tests. I recommend additional validation in a staging environment to confirm scalability under higher user loads.