### PR TITLE
feat(gs): Ban frequent socket abusers

### DIFF
--- a/gameServer/src/WebSocketManager.js
+++ b/gameServer/src/WebSocketManager.js
@@ -2,7 +2,7 @@ import { RateLimitManager } from "../../shared/RateLimitManager.js";
 import { WebSocketConnection } from "./WebSocketConnection.js";
 import { getMainInstance } from "./mainInstance.js";
 import { WebSocketHoster } from "./util/WebSocketHoster.js";
-import { DinoRateLimiter } from "./util/SocketRateLimiter.js";
+import { BanHandler, DinoRateLimiter } from "./util/SocketRateLimiter.js";
 
 export class WebSocketManager {
 	#hoster;
@@ -34,6 +34,14 @@ export class WebSocketManager {
 				onRateLimitExceeded: () => {
 					socket.close();
 				},
+				banHandler: new BanHandler({
+					ip: ip,
+					banDurationInSeconds: 600,
+					banThreshold: 3,
+					onBan: () => {
+						socket.close();
+					},
+				}),
 			});
 
 			socket.addEventListener("message", async (message) => {

--- a/gameServer/src/WebSocketManager.js
+++ b/gameServer/src/WebSocketManager.js
@@ -33,7 +33,7 @@ export class WebSocketManager {
 				interval: 100,
 				onRateLimitExceeded: () => {
 					socket.close();
-				}
+				},
 			});
 
 			socket.addEventListener("message", async (message) => {

--- a/gameServer/src/util/SocketRateLimiter.js
+++ b/gameServer/src/util/SocketRateLimiter.js
@@ -1,7 +1,7 @@
 /**
  * Limit the number of messages sent to the server within a time interval
  * to guard against socket abuse.
- * 
+ *
  * @example
  * const rateLimiter = new DinoRateLimiter({
  *    maxMessages: 20, // Allow a maximum of 20 messages
@@ -10,7 +10,7 @@
  *        socket.close(); // close the connection when limit is exceeded
  *    }
  * });
- * 
+ *
  * // Trigger the tick() method when a message is received
  * if (rateLimiter.tick()) {
  *    console.log('Rate limit exceeded');
@@ -20,47 +20,47 @@
  */
 
 export class DinoRateLimiter {
-    /**
-     * @param {Object} options - Configurations
-     * @param {number} options.maxMessages - Maximum number of messages allowed in the time interval.
-     * @param {number} options.interval - Time interval in milliseconds for the rate limit.
-     * @param {Function} [options.onRateLimitExceeded] - Optional callback to invoke when the rate limit is exceeded.
-     */
-    constructor({ maxMessages, interval, onRateLimitExceeded = undefined }) {
-        /** @type {number[]} */
-        this.messageTimeQueue = [];
-        this.maxMessages = maxMessages;
-        this.interval = interval;
-        this.onRateLimitExceeded = onRateLimitExceeded;
-    }
+	/**
+	 * @param {Object} options - Configurations
+	 * @param {number} options.maxMessages - Maximum number of messages allowed in the time interval.
+	 * @param {number} options.interval - Time interval in milliseconds for the rate limit.
+	 * @param {Function} [options.onRateLimitExceeded] - Optional callback to invoke when the rate limit is exceeded.
+	 */
+	constructor({ maxMessages, interval, onRateLimitExceeded = undefined }) {
+		/** @type {number[]} */
+		this.messageTimeQueue = [];
+		this.maxMessages = maxMessages;
+		this.interval = interval;
+		this.onRateLimitExceeded = onRateLimitExceeded;
+	}
 
-    /**
-     * Checks if the rate limit is exceeded and pushes the message timestamp to the 
-     * message queue. This method must be called every time a message is received. 
-     * If the rate limit is reached, it executes the `onRateLimitExceeded` callback.
-     *
-     * @returns {boolean} - Returns true if the rate limit is exceeded, otherwise false.
-     * 
-     * @callback onRateLimitExceeded
-     * @description Callback function that is executed when the rate limit is exceeded.
-     */
-    tick() {
-        const now = Date.now();
-        this.messageTimeQueue.push(now);
+	/**
+	 * Checks if the rate limit is exceeded and pushes the message timestamp to the
+	 * message queue. This method must be called every time a message is received.
+	 * If the rate limit is reached, it executes the `onRateLimitExceeded` callback.
+	 *
+	 * @returns {boolean} - Returns true if the rate limit is exceeded, otherwise false.
+	 *
+	 * @callback onRateLimitExceeded
+	 * @description Callback function that is executed when the rate limit is exceeded.
+	 */
+	tick() {
+		const now = Date.now();
+		this.messageTimeQueue.push(now);
 
-        // remove old message timestamps
-        while (this.messageTimeQueue.length > 0 && now - this.messageTimeQueue[0] > this.interval) {
-            this.messageTimeQueue.shift();
-        }
+		// remove old message timestamps
+		while (this.messageTimeQueue.length > 0 && now - this.messageTimeQueue[0] > this.interval) {
+			this.messageTimeQueue.shift();
+		}
 
-        // console.log(this.messageTimeQueue.length); // DEBUG
+		// console.log(this.messageTimeQueue.length); // DEBUG
 
-        if (this.messageTimeQueue.length > this.maxMessages) {
-            if (this.onRateLimitExceeded) {
-                this.onRateLimitExceeded();
-            }
-            return true;
-        }
-        return false;
-    }
+		if (this.messageTimeQueue.length > this.maxMessages) {
+			if (this.onRateLimitExceeded) {
+				this.onRateLimitExceeded();
+			}
+			return true;
+		}
+		return false;
+	}
 }

--- a/gameServer/src/util/SocketRateLimiter.js
+++ b/gameServer/src/util/SocketRateLimiter.js
@@ -1,0 +1,65 @@
+/**
+ * Limit the number of messages sent to the server within a time interval
+ * to guard against socket abuse.
+ * 
+ * @example
+ * const rateLimiter = new DinoRateLimiter({
+ *    maxMessages: 20, // Allow a maximum of 20 messages
+ *    interval: 100, // Within a 100ms time window
+ *    onRateLimitExceeded: () => {
+ *        socket.close(); // close the connection when limit is exceeded
+ *    }
+ * });
+ * 
+ * // Trigger the tick() method when a message is received
+ * if (rateLimiter.tick()) {
+ *    console.log('Rate limit exceeded');
+ * } else {
+ *    console.log('Message received');
+ * }
+ */
+
+export class DinoRateLimiter {
+    /**
+     * @param {Object} options - Configurations
+     * @param {number} options.maxMessages - Maximum number of messages allowed in the time interval.
+     * @param {number} options.interval - Time interval in milliseconds for the rate limit.
+     * @param {Function} [options.onRateLimitExceeded] - Optional callback to invoke when the rate limit is exceeded.
+     */
+    constructor({ maxMessages, interval, onRateLimitExceeded = undefined }) {
+        /** @type {number[]} */
+        this.messageTimeQueue = [];
+        this.maxMessages = maxMessages;
+        this.interval = interval;
+        this.onRateLimitExceeded = onRateLimitExceeded;
+    }
+
+    /**
+     * Checks if the rate limit is exceeded and pushes the message timestamp to the 
+     * message queue. This method must be called every time a message is received. 
+     * If the rate limit is reached, it executes the `onRateLimitExceeded` callback.
+     *
+     * @returns {boolean} - Returns true if the rate limit is exceeded, otherwise false.
+     * 
+     * @callback onRateLimitExceeded
+     * @description Callback function that is executed when the rate limit is exceeded.
+     */
+    tick() {
+        const now = Date.now();
+        this.messageTimeQueue.push(now);
+
+        // remove old message timestamps
+        while (this.messageTimeQueue.length > 0 && now - this.messageTimeQueue[0] > this.interval) {
+            this.messageTimeQueue.shift();
+        }
+
+        // console.log(this.messageTimeQueue.length); // DEBUG
+
+        if (this.messageTimeQueue.length > this.maxMessages && this.onRateLimitExceeded) {
+            this.onRateLimitExceeded();
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/gameServer/src/util/SocketRateLimiter.js
+++ b/gameServer/src/util/SocketRateLimiter.js
@@ -55,11 +55,12 @@ export class DinoRateLimiter {
 
         // console.log(this.messageTimeQueue.length); // DEBUG
 
-        if (this.messageTimeQueue.length > this.maxMessages && this.onRateLimitExceeded) {
-            this.onRateLimitExceeded();
+        if (this.messageTimeQueue.length > this.maxMessages) {
+            if (this.onRateLimitExceeded) {
+                this.onRateLimitExceeded();
+            }
             return true;
         }
-
         return false;
     }
 }

--- a/gameServer/src/util/SocketRateLimiter.js
+++ b/gameServer/src/util/SocketRateLimiter.js
@@ -9,6 +9,14 @@
  *    onRateLimitExceeded: () => {
  *        socket.close(); // close the connection when limit is exceeded
  *    }
+ *    banHandler: new BanHandler({
+ * 		  ip: ip,
+ * 		  banDurationInSeconds: 600,
+ * 	      banThreshold: 3,
+ * 		  onBan: () => {
+ * 			socket.close();
+ * 		  },
+ * 	  }),
  * });
  *
  * // Trigger the tick() method when a message is received
@@ -18,20 +26,21 @@
  *    console.log('Message received');
  * }
  */
-
-export class DinoRateLimiter {
+class DinoRateLimiter {
 	/**
 	 * @param {Object} options - Configurations
 	 * @param {number} options.maxMessages - Maximum number of messages allowed in the time interval.
 	 * @param {number} options.interval - Time interval in milliseconds for the rate limit.
-	 * @param {Function} [options.onRateLimitExceeded] - Optional callback to invoke when the rate limit is exceeded.
+	 * @param {Function} [options.onRateLimitExceeded] - Optional callback to invoke when the ratelimit is exceeded.
+	 * @param {BanHandler} [options.banHandler] - Optional ban handler to ban abusive clients.
 	 */
-	constructor({ maxMessages, interval, onRateLimitExceeded = undefined }) {
+	constructor({ maxMessages, interval, onRateLimitExceeded, banHandler }) {
 		/** @type {number[]} */
 		this.messageTimeQueue = [];
 		this.maxMessages = maxMessages;
 		this.interval = interval;
 		this.onRateLimitExceeded = onRateLimitExceeded;
+		this.banHandler = banHandler;
 	}
 
 	/**
@@ -39,28 +48,96 @@ export class DinoRateLimiter {
 	 * message queue. This method must be called every time a message is received.
 	 * If the rate limit is reached, it executes the `onRateLimitExceeded` callback.
 	 *
-	 * @returns {boolean} - Returns true if the rate limit is exceeded, otherwise false.
-	 *
-	 * @callback onRateLimitExceeded
-	 * @description Callback function that is executed when the rate limit is exceeded.
+	 * @returns {boolean} True if the rate limit is exceeded, otherwise false.
 	 */
 	tick() {
+		if (this.banHandler) BanHandler.checkFrequentAbuse(this.banHandler);
+
 		const now = Date.now();
 		this.messageTimeQueue.push(now);
 
-		// remove old message timestamps
-		while (this.messageTimeQueue.length > 0 && now - this.messageTimeQueue[0] > this.interval) {
+		while (this.messageTimeQueue.length && now - this.messageTimeQueue[0] > this.interval) {
 			this.messageTimeQueue.shift();
 		}
 
-		// console.log(this.messageTimeQueue.length); // DEBUG
-
 		if (this.messageTimeQueue.length > this.maxMessages) {
-			if (this.onRateLimitExceeded) {
-				this.onRateLimitExceeded();
-			}
+			if (this.onRateLimitExceeded) this.onRateLimitExceeded();
+			if (this.banHandler) BanHandler.tick(this.banHandler);
 			return true;
 		}
 		return false;
 	}
 }
+
+/**
+ * Handles banning abusive clients based on socket activity.
+ */
+class BanHandler {
+	/**
+	 * @param {Object} options - Configurations
+	 * @param {string} options.ip - IP address of the client.
+	 * @param {number} options.banDurationInSeconds - Time period the player stays banned.
+	 * @param {number} options.banThreshold - Number of socket abuses to trigger a ban.
+	 * @param {Function} options.onBan - Callback to invoke when a client is banned.
+	 */
+	constructor({ ip, banDurationInSeconds, banThreshold, onBan }) {
+		this.ip = ip;
+		this.banThreshold = banThreshold;
+		this.onBan = onBan;
+		this.banDuration = banDurationInSeconds * 1000;
+	}
+
+	/** @type {{[key: string]: number[]}} */
+	static abuseLog = {};
+
+	/**
+	 * Logs an abuse instance for the specified handler.
+	 * @param {BanHandler} handler - The banhandler for the client.
+	 */
+	static tick(handler) {
+		this.abuseLog[handler.ip] ||= [];
+		this.abuseLog[handler.ip].push(Date.now());
+	}
+
+	/**
+	 * Block if client exceeds the ban threshold.
+	 * @param {BanHandler} handler - The banhandler for the client.
+	 * @returns {boolean} True if the ban threshold is exceeded, otherwise false.
+	 */
+	static checkFrequentAbuse(handler) {
+		this.abuseLog[handler.ip] ||= [];
+		while (
+			this.abuseLog[handler.ip].length &&
+			Date.now() - this.abuseLog[handler.ip][0] > handler.banDuration
+		) {
+			this.abuseLog[handler.ip].shift();
+		}
+
+		if (this.abuseLog[handler.ip].length >= handler.banThreshold) {
+			handler.onBan();
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Cleans up the abuse log for entries beyond the maximum ban duration.
+	 * Dino no like memory leaks.
+	 */
+	static maxBanDuration = 2 * 3600_000;
+	static cleanupInterval = 3600_000;
+
+	static abuseLogCleaner = setInterval(() => {
+		for (const ip in this.abuseLog) {
+			while (
+				this.abuseLog[ip].length &&
+				Date.now() - this.abuseLog[ip][0] > this.maxBanDuration
+			) {
+				this.abuseLog[ip].shift();
+			}
+			if (!this.abuseLog[ip].length) delete this.abuseLog[ip];
+		}
+	}, this.cleanupInterval);
+}
+
+export { BanHandler, DinoRateLimiter };


### PR DESCRIPTION
Upgrades #153 

Bans socket abusers who exceed a threshold of 3 abuses within the last 10 minutes.

### Configuration:

**Ban Trigger**: 3 abuses in 10mins.

### Testing:

I tested extensively with my local IP and with simulated multiple IPs (by modifying the IP string predictably random).

Although I haven't tested with real multiple IPs, dino is lazieeee and hates testing :((

### Future Improvements:

I'm thinking it would be greaaat to remove event listeners from the socket and keep it alive instead of disconnecting it. Let the abuser think, "ugh.. I can already toast a bread on my computer, but why isn't the server lagging yet? huh?", it's the wrath of dino.. muahahaha

### Notes:

A sneaky abuser could try once every 3min 21sec  without getting banned, but that's fine, they can't do any harm to the servers anyway.
