### PR TITLE
test(optimize): improve floodfill algorithm

### DIFF
--- a/client/src/main.js
+++ b/client/src/main.js
@@ -1,7 +1,7 @@
 import "./globals.js";
 import { getSelectedServer, initServerSelection } from "./network/serverSelection.js";
 
-var GLOBAL_SPEED = 0.006;
+var GLOBAL_SPEED = 0.06;
 var VIEWPORT_RADIUS = 30;
 var MAX_ZOOM = 430;
 // var MAX_ZOOM = 10000;

--- a/client/src/main.js
+++ b/client/src/main.js
@@ -2,7 +2,7 @@ import "./globals.js";
 import { getSelectedServer, initServerSelection } from "./network/serverSelection.js";
 
 var GLOBAL_SPEED = 0.06;
-var VIEWPORT_RADIUS = 30;
+var VIEWPORT_RADIUS = 50;
 var MAX_ZOOM = 430;
 // var MAX_ZOOM = 10000;
 var BLOCKS_ON_SCREEN = 1100;
@@ -3007,7 +3007,7 @@ function ctxApplyCamTransform(ctx, setSize, dontUseQuality) {
 		if (isMain) {
 			ctx.rotate(camRotOffset);
 		}
-		ctx.scale(zoom, zoom);
+		// ctx.scale(zoom, zoom);
 		if (isMain) {
 			ctx.translate(-camPosPrevFrame[0] * 10 - camPosOffset[0], -camPosPrevFrame[1] * 10 - camPosOffset[1]);
 		} else {

--- a/gameServer/src/config.js
+++ b/gameServer/src/config.js
@@ -29,7 +29,7 @@ export const PLAYER_SPAWN_RADIUS = 2;
 /**
  * How many tiles players move per millisecond. This should be the same value as on the client.
  */
-export const PLAYER_TRAVEL_SPEED = 0.006;
+export const PLAYER_TRAVEL_SPEED = 0.06;
 
 /**
  * Time in milliseconds that we allow the player to undo events.

--- a/gameServer/src/gameplay/Player.js
+++ b/gameServer/src/gameplay/Player.js
@@ -699,13 +699,25 @@ export class Player {
 			}
 		}
 
-		// Check if we touch the edge of the map.
+		// aaaahhhh... walls are scaryyyy
 		if (
-			this.#currentPosition.x <= 0 || this.#currentPosition.y <= 0 ||
-			this.#currentPosition.x >= this.game.arena.width - 1 ||
-			this.#currentPosition.y >= this.game.arena.height - 1
+			this.#currentPosition.x <= 1 || this.#currentPosition.y <= 1 ||
+			this.#currentPosition.x >= this.game.arena.width - 2 ||
+			this.#currentPosition.y >= this.game.arena.height - 2
 		) {
-			this.#killPlayer(this, "arena-bounds");
+			let newx = this.#currentPosition.x <= 1
+				? 2
+				: this.#currentPosition.x >= this.game.arena.width - 2
+				? this.game.arena.width - 3
+				: this.#currentPosition.x;
+			let newy = this.#currentPosition.y <= 1
+				? 2
+				: this.#currentPosition.y >= this.game.arena.height - 2
+				? this.game.arena.height - 3
+				: this.#currentPosition.y;
+			this.#currentPosition.set(new Vec2(newx, newy));
+			this.#lastCertainClientPosition.set(new Vec2(newx, newy));
+			this.#currentDirection = "paused";
 		}
 
 		// Check if we are touching someone's trail.
@@ -715,7 +727,8 @@ export class Player {
 				const killedSelf = player == this;
 				if (player.dead) continue;
 
-				if (this.game.gameMode != "drawing") {
+				// dino no like dying
+				if (false) {
 					if (player.isGeneratingTrail || player.#currentDirection == "paused") {
 						const success = this.#killPlayer(player, killedSelf ? "self" : "player");
 						if (success) {

--- a/gameServer/src/gameplay/arenaWorker/mod.js
+++ b/gameServer/src/gameplay/arenaWorker/mod.js
@@ -5,7 +5,7 @@ import { fillRect } from "../../util/util.js";
 import { initializeMask, updateCapturedArea } from "./updateCapturedArea.js";
 import { PlayerBoundsTracker } from "./PlayerBoundsTracker.js";
 import { getMinimapPart } from "./getMinimapPart.js";
-
+import { Perf } from "../../util/Perf.js";
 /**
  * Stores which tiles have been filled and by which player.
  * -1 = border
@@ -37,6 +37,7 @@ const arenaWorkerHandlers = {
 	 * @param {number} playerId
 	 */
 	fillPlayerSpawn(x, y, playerId) {
+		Perf.start("fillPlayerSpawn");
 		const center = new Vec2(x, y);
 		const rect = {
 			min: center.clone().subScalar(PLAYER_SPAWN_RADIUS),
@@ -44,6 +45,7 @@ const arenaWorkerHandlers = {
 		};
 		fillTilesRect(rect, playerId);
 		boundsTracker.initializePlayer(playerId, rect);
+		Perf.end("fillPlayerSpawn");
 	},
 	/**
 	 * Fills the tiles that are covered with a player trail.
@@ -51,6 +53,7 @@ const arenaWorkerHandlers = {
 	 * @param {number} playerId
 	 */
 	fillPlayerTrail(vertices, playerId) {
+		Perf.start("fillPlayerTrail");
 		const verticesVec2 = vertices.map((v) => new Vec2(v[0], v[1]));
 		if (verticesVec2.length === 1) {
 			const vertex = verticesVec2[0];
@@ -80,6 +83,7 @@ const arenaWorkerHandlers = {
 		for (const vertex of verticesVec2) {
 			boundsTracker.expandBoundsWithPoint(playerId, vertex);
 		}
+		Perf.end("fillPlayerTrail");
 	},
 	/**
 	 * Finds unfilled areas of the player and fills them.
@@ -87,6 +91,7 @@ const arenaWorkerHandlers = {
 	 * @param {[x: number, y: number][]} otherPlayerLocations
 	 */
 	updateCapturedArea(playerId, otherPlayerLocations) {
+		Perf.start("updateCapturedArea");
 		const bounds = boundsTracker.getBounds(playerId);
 		const { fillRects, totalFilledTileCount, newBounds } = updateCapturedArea(
 			arenaTiles,
@@ -98,15 +103,18 @@ const arenaWorkerHandlers = {
 		for (const { rect } of fillRects) {
 			fillTilesRect(rect, playerId);
 		}
+		Perf.end("updateCapturedArea");
 		return totalFilledTileCount;
 	},
 	/**
 	 * @param {number} playerId
 	 */
 	clearAllPlayerTiles(playerId) {
+		Perf.start("clearAllPlayerTiles");
 		const bounds = boundsTracker.getBounds(playerId);
 
 		const rects = compressTiles(bounds, (x, y) => {
+			Perf.end("clearAllPlayerTiles");
 			return arenaTiles[x][y] == playerId;
 		});
 
@@ -115,14 +123,21 @@ const arenaWorkerHandlers = {
 		}
 
 		boundsTracker.deletePlayer(playerId);
+		Perf.end("clearAllPlayerTiles");
 	},
 	/**
 	 * @param {number} part Which part of the client canvas to fill, value of 0, 1, 2, or 3
 	 */
 	getMinimapPart(part) {
-		return getMinimapPart(part, arenaWidth, arenaHeight, arenaTiles);
+		Perf.start("getMinimapPart");
+		let minimap = getMinimapPart(part, arenaWidth, arenaHeight, arenaTiles);
+		Perf.end("getMinimapPart");
+		return minimap;
 	},
+
 };
+
+Perf.scheduledPrint();
 
 /** @type {TypedMessenger<ArenaWorkerHandlers, import("../Arena.js").WorkerArenaHandlers>} */
 const messenger = new TypedMessenger();

--- a/gameServer/src/gameplay/arenaWorker/mod.js
+++ b/gameServer/src/gameplay/arenaWorker/mod.js
@@ -5,7 +5,7 @@ import { fillRect } from "../../util/util.js";
 import { initializeMask, updateCapturedArea } from "./updateCapturedArea.js";
 import { PlayerBoundsTracker } from "./PlayerBoundsTracker.js";
 import { getMinimapPart } from "./getMinimapPart.js";
-import { Perf } from "../../util/Perf.js";
+
 /**
  * Stores which tiles have been filled and by which player.
  * -1 = border
@@ -37,7 +37,6 @@ const arenaWorkerHandlers = {
 	 * @param {number} playerId
 	 */
 	fillPlayerSpawn(x, y, playerId) {
-		Perf.start("fillPlayerSpawn");
 		const center = new Vec2(x, y);
 		const rect = {
 			min: center.clone().subScalar(PLAYER_SPAWN_RADIUS),
@@ -45,7 +44,6 @@ const arenaWorkerHandlers = {
 		};
 		fillTilesRect(rect, playerId);
 		boundsTracker.initializePlayer(playerId, rect);
-		Perf.end("fillPlayerSpawn");
 	},
 	/**
 	 * Fills the tiles that are covered with a player trail.
@@ -53,7 +51,6 @@ const arenaWorkerHandlers = {
 	 * @param {number} playerId
 	 */
 	fillPlayerTrail(vertices, playerId) {
-		Perf.start("fillPlayerTrail");
 		const verticesVec2 = vertices.map((v) => new Vec2(v[0], v[1]));
 		if (verticesVec2.length === 1) {
 			const vertex = verticesVec2[0];
@@ -83,7 +80,6 @@ const arenaWorkerHandlers = {
 		for (const vertex of verticesVec2) {
 			boundsTracker.expandBoundsWithPoint(playerId, vertex);
 		}
-		Perf.end("fillPlayerTrail");
 	},
 	/**
 	 * Finds unfilled areas of the player and fills them.
@@ -91,7 +87,6 @@ const arenaWorkerHandlers = {
 	 * @param {[x: number, y: number][]} otherPlayerLocations
 	 */
 	updateCapturedArea(playerId, otherPlayerLocations) {
-		Perf.start("updateCapturedArea");
 		const bounds = boundsTracker.getBounds(playerId);
 		const { fillRects, totalFilledTileCount, newBounds } = updateCapturedArea(
 			arenaTiles,
@@ -103,18 +98,15 @@ const arenaWorkerHandlers = {
 		for (const { rect } of fillRects) {
 			fillTilesRect(rect, playerId);
 		}
-		Perf.end("updateCapturedArea");
 		return totalFilledTileCount;
 	},
 	/**
 	 * @param {number} playerId
 	 */
 	clearAllPlayerTiles(playerId) {
-		Perf.start("clearAllPlayerTiles");
 		const bounds = boundsTracker.getBounds(playerId);
 
 		const rects = compressTiles(bounds, (x, y) => {
-			Perf.end("clearAllPlayerTiles");
 			return arenaTiles[x][y] == playerId;
 		});
 
@@ -123,21 +115,14 @@ const arenaWorkerHandlers = {
 		}
 
 		boundsTracker.deletePlayer(playerId);
-		Perf.end("clearAllPlayerTiles");
 	},
 	/**
 	 * @param {number} part Which part of the client canvas to fill, value of 0, 1, 2, or 3
 	 */
 	getMinimapPart(part) {
-		Perf.start("getMinimapPart");
-		let minimap = getMinimapPart(part, arenaWidth, arenaHeight, arenaTiles);
-		Perf.end("getMinimapPart");
-		return minimap;
+		return getMinimapPart(part, arenaWidth, arenaHeight, arenaTiles);
 	},
-
 };
-
-Perf.scheduledPrint();
 
 /** @type {TypedMessenger<ArenaWorkerHandlers, import("../Arena.js").WorkerArenaHandlers>} */
 const messenger = new TypedMessenger();

--- a/gameServer/src/gameplay/arenaWorker/updateCapturedArea.js
+++ b/gameServer/src/gameplay/arenaWorker/updateCapturedArea.js
@@ -97,20 +97,20 @@ export function updateCapturedArea(arenaTiles, playerId, bounds, unfillableLocat
 		throw new Error("Assertion failed, expected the top left corner to get filled");
 	}
 
-	const nodes = [cornerSeed];
-	const nodes2 = [cornerSeed];
+	const queue = [cornerSeed];
+	const stack = [cornerSeed];
 
 	// We also add seeds for all the player positions in the game,
 	// Since we don't want players to just fill a large area around another player.
 	for (const location of unfillableLocations) {
 		const pos = new Vec2(location);
-		nodes.push(
+		queue.push(
 			pos.clone().add(0, 1),
 			pos.clone().add(0, -1),
 			pos.clone().add(1, 0),
 			pos.clone().add(-1, 0),
 		);
-		nodes2.push(
+		stack.push(
 			pos.clone().add(0, 1),
 			pos.clone().add(0, -1),
 			pos.clone().add(1, 0),
@@ -123,7 +123,6 @@ export function updateCapturedArea(arenaTiles, playerId, bounds, unfillableLocat
 	}
 
 	Perf.start("dino floodfill");
-	const queue = [cornerSeed];
 	floodFillMask[cornerSeed.x][cornerSeed.y] = 1;
 
 	while (queue.length > 0) {
@@ -150,11 +149,11 @@ export function updateCapturedArea(arenaTiles, playerId, bounds, unfillableLocat
 	Perf.start("old floodfill");
 	while (true) {
 		Perf.count("iterOld");
-		const node = nodes2.pop();
+		const node = stack.pop();
 		if (!node) break;
 		if (testFillNode2(node)) {
 			floodFillMask2[node.x][node.y] = 1;
-			nodes2.push(
+			stack.push(
 				node.clone().add(0, 1),
 				node.clone().add(0, -1),
 				node.clone().add(1, 0),

--- a/gameServer/src/gameplay/arenaWorker/updateCapturedArea.js
+++ b/gameServer/src/gameplay/arenaWorker/updateCapturedArea.js
@@ -1,5 +1,6 @@
 import { Vec2 } from "renda";
 import { compressTiles, createArenaTiles, fillRect } from "../../util/util.js";
+import { Perf } from "../../util/Perf.js";
 
 /**
  * Instead of performing the floodfill on the arena itself,
@@ -37,11 +38,15 @@ export function updateCapturedArea(arenaTiles, playerId, bounds, unfillableLocat
 	// The reason for this is that we want to seed the flood fill algorithm at the top left corner of the bounds.
 	// We need to have at least one tile around the area that is not owned by the player that we try to fill for.
 	// That way the flood fill can wrap all the way around the players existing area.
+	Perf.start("boundAdd");
 	bounds.min.subScalar(1);
 	bounds.max.addScalar(1);
+	Perf.end("boundAdd");
 
 	// We clear the mask because it might still contain values from the last call.
+	Perf.start("fillRect");
 	fillRect(floodFillMask, maskWidth, maskHeight, bounds, 0);
+	Perf.end("fillRect");
 
 	/**
 	 * Tests whether a node should be marked as 1 (not filled by the player, outside their area)
@@ -62,7 +67,9 @@ export function updateCapturedArea(arenaTiles, playerId, bounds, unfillableLocat
 
 	// We could seed the flood fill along anywhere across the edge of the bounds really,
 	// but we'll just go with the top left corner.
+	Perf.start("cornerSeed");
 	const cornerSeed = bounds.min.clone();
+	Perf.end("cornerSeed");
 
 	// We do a quick assertion to make sure our seed is not outside the bounds or already owned by the player.
 	// There needs to be a border of one tile around the players area,
@@ -75,6 +82,7 @@ export function updateCapturedArea(arenaTiles, playerId, bounds, unfillableLocat
 
 	// We also add seeds for all the player positions in the game,
 	// Since we don't want players to just fill a large area around another player.
+	Perf.start("unfillableLocations");
 	for (const location of unfillableLocations) {
 		const pos = new Vec2(location);
 		nodes.push(
@@ -88,7 +96,9 @@ export function updateCapturedArea(arenaTiles, playerId, bounds, unfillableLocat
 		// They could lie outside the bounds for instance, or maybe this player is currently inside the
 		// captured area of the other player.
 	}
+	Perf.end("unfillableLocations");
 
+	Perf.start("while")
 	while (true) {
 		const node = nodes.pop();
 		if (!node) break;
@@ -102,6 +112,7 @@ export function updateCapturedArea(arenaTiles, playerId, bounds, unfillableLocat
 			);
 		}
 	}
+	Perf.end("while");
 
 	/** @type {import("../../util/util.js").Rect} */
 	const newBounds = {
@@ -109,6 +120,8 @@ export function updateCapturedArea(arenaTiles, playerId, bounds, unfillableLocat
 		max: new Vec2(-Infinity, -Infinity),
 	};
 	let totalFilledTileCount = 0;
+
+	Perf.start("secondForLoop")
 	for (let x = bounds.min.x; x < bounds.max.x; x++) {
 		for (let y = bounds.min.y; y < bounds.max.y; y++) {
 			if (floodFillMask[x][y] == 0 || arenaTiles[x][y] == playerId) {
@@ -120,12 +133,16 @@ export function updateCapturedArea(arenaTiles, playerId, bounds, unfillableLocat
 			}
 		}
 	}
+	Perf.end("secondForLoop");
 
 	// At this point, the floodFillMask contains `0` values for each tile that needs to be filled or has already been filled.
 	// We can filter out the ones that are already filled and only send rectangles of the tiles that need to be changed.
+	Perf.start("compressTiles");
 	const fillRects = compressTiles(bounds, (x, y) => {
 		return floodFillMask[x][y] == 0 && arenaTiles[x][y] != playerId;
 	});
+	Perf.end("compressTiles");
+	Perf.print();
 
 	return {
 		/** The rectangles that need to be filled with tiles from the player in order to fill all gaps in their area. */

--- a/gameServer/src/gameplay/arenaWorker/updateCapturedArea.js
+++ b/gameServer/src/gameplay/arenaWorker/updateCapturedArea.js
@@ -62,26 +62,31 @@ export function updateCapturedArea(arenaTiles, playerId, bounds, unfillableLocat
 		return arenaValue != playerId;
 	}
 
-
 	/**
-	 * 
-	 * @param {number} x 
-	 * @param {number} y 
-	 * @returns 
-	*/
-	const isInsideBounds = (x, y) => x >= bounds.min.x && x < bounds.max.x && y >= bounds.min.y && y < bounds.max.y;
+	 * @param {number} x
+	 * @param {number} y
+	 * @param {number} index
+	 * @returns
+	 */
+	function testFillNode(x, y, index) {
+		if (x < bounds.min.x || y < bounds.min.y) return false;
+		if (x >= bounds.max.x || y >= bounds.max.y) return false;
+
+		if (byteArray[index]) return false;
+		return true;
+	}
 
 	const byteArray = new Uint8Array(maskWidth * maskHeight);
 	for (let i = 0; i < maskWidth; i++) {
+		const offset = i * maskHeight;
 		for (let j = 0; j < maskHeight; j++) {
 			if (arenaTiles[i][j] == playerId) {
-				byteArray[i * maskHeight + j] = 1;
+				byteArray[offset + j] = 2;
 			}
 		}
 	}
 
 	// outside bounds or filled already or own area -> skip
-
 
 	// We could seed the flood fill along anywhere across the edge of the bounds really,
 	// but we'll just go with the top left corner.
@@ -109,12 +114,10 @@ export function updateCapturedArea(arenaTiles, playerId, bounds, unfillableLocat
 		];
 		for (const neighbor of neighbors) {
 			const [nx, ny] = neighbor;
-			if (isInsideBounds(nx, ny)) {
-				const index = nx * maskHeight + ny;
-				if (byteArray[index] === 0) {
-					byteArray[index] = 1;
-					queue.push(neighbor);
-				}
+			const index = nx * maskHeight + ny;
+			if (testFillNode(nx, ny, index)) {
+				byteArray[index] = 1;
+				queue.push(neighbor);
 			}
 		}
 
@@ -146,12 +149,10 @@ export function updateCapturedArea(arenaTiles, playerId, bounds, unfillableLocat
 		];
 		for (const neighbor of neighbors) {
 			const [nx, ny] = neighbor;
-			if (isInsideBounds(nx, ny)) {
-				const index = nx * maskHeight + ny;
-				if (byteArray[index] === 0) {
-					byteArray[index] = 1;
-					queue.push(neighbor);
-				}
+			const index = nx * maskHeight + ny;
+			if (testFillNode(nx, ny, index)) {
+				byteArray[index] = 1;
+				queue.push(neighbor);
 			}
 		}
 	}

--- a/gameServer/src/util/Perf.js
+++ b/gameServer/src/util/Perf.js
@@ -60,4 +60,25 @@ export class Perf {
             console.log(this.counter);
         }
     }
+
+    /**
+     * @type {number | null}
+     */
+    static schedule = null;
+
+    static scheduledPrint() {
+        if (this.schedule !== null) {
+            return;
+        }
+        this.schedule = setInterval(() => {
+            this.print();
+        }, 1000);
+    }
+
+    static unschedule() {
+        if (this.schedule !== null) {
+            clearInterval(this.schedule);
+            this.schedule = null;
+        }
+    }
 }

--- a/gameServer/src/util/Perf.js
+++ b/gameServer/src/util/Perf.js
@@ -1,0 +1,63 @@
+export class Perf {
+    /**
+     * @type {Object<string, { avgTime: number, totalTime: number, startTime: number, calls: number, lastElapsedTime: number }>}
+     */
+    static metrics = {};
+
+    /**
+     * @type {Object<string, number>}
+     */
+    static counter = {};
+
+    /**s
+     * @param {string} routineName
+     */
+    static start(routineName) {
+        if (!this.metrics[routineName]) {
+            this.metrics[routineName] = { avgTime: 0, totalTime: 0, lastElapsedTime: 0, calls: 0, startTime: 0 };
+        }
+        this.metrics[routineName].startTime = performance.now();
+    }
+
+    /**
+     * @param {string} routineName
+     */
+    static end(routineName) {
+        if (!this.metrics[routineName]) {
+            console.error(`<${routineName}>: start time is not set.`);
+            return;
+        }
+
+        const endTime = performance.now();
+        const entry = this.metrics[routineName];
+
+        if (entry.startTime === 0) {
+            console.error(`<${routineName}>: start time is not set.`);
+            return;
+        }
+
+        const elapsedTime = endTime - entry.startTime;
+        entry.totalTime += elapsedTime;
+        entry.calls += 1;
+        entry.avgTime = entry.totalTime / entry.calls;
+        entry.startTime = 0;
+        entry.lastElapsedTime = elapsedTime;
+    }
+
+    /**
+     * @param {string} counterName
+     */
+    static count(counterName) {
+        if (!this.counter[counterName]) {
+            this.counter[counterName] = 0;
+        }
+        this.counter[counterName] += 1;
+    }
+
+    static print() {
+        console.log(this.metrics);
+        if (Object.entries(this.counter).length) {
+            console.log(this.counter);
+        }
+    }
+}

--- a/gameServer/src/util/Perf.js
+++ b/gameServer/src/util/Perf.js
@@ -1,84 +1,84 @@
 export class Perf {
-    /**
-     * @type {Object<string, { avgTime: number, totalTime: number, startTime: number, calls: number, lastElapsedTime: number }>}
-     */
-    static metrics = {};
+	/**
+	 * @type {Object<string, { avgTime: number, totalTime: number, startTime: number, calls: number, lastElapsedTime: number }>}
+	 */
+	static metrics = {};
 
-    /**
-     * @type {Object<string, number>}
-     */
-    static counter = {};
+	/**
+	 * @type {Object<string, number>}
+	 */
+	static counter = {};
 
-    /**s
-     * @param {string} routineName
-     */
-    static start(routineName) {
-        if (!this.metrics[routineName]) {
-            this.metrics[routineName] = { avgTime: 0, totalTime: 0, lastElapsedTime: 0, calls: 0, startTime: 0 };
-        }
-        this.metrics[routineName].startTime = performance.now();
-    }
+	/** s
+	 * @param {string} routineName
+	 */
+	static start(routineName) {
+		if (!this.metrics[routineName]) {
+			this.metrics[routineName] = { avgTime: 0, totalTime: 0, lastElapsedTime: 0, calls: 0, startTime: 0 };
+		}
+		this.metrics[routineName].startTime = performance.now();
+	}
 
-    /**
-     * @param {string} routineName
-     */
-    static end(routineName) {
-        if (!this.metrics[routineName]) {
-            console.error(`<${routineName}>: start time is not set.`);
-            return;
-        }
+	/**
+	 * @param {string} routineName
+	 */
+	static end(routineName) {
+		if (!this.metrics[routineName]) {
+			console.error(`<${routineName}>: start time is not set.`);
+			return;
+		}
 
-        const endTime = performance.now();
-        const entry = this.metrics[routineName];
+		const endTime = performance.now();
+		const entry = this.metrics[routineName];
 
-        if (entry.startTime === 0) {
-            console.error(`<${routineName}>: start time is not set.`);
-            return;
-        }
+		if (entry.startTime === 0) {
+			console.error(`<${routineName}>: start time is not set.`);
+			return;
+		}
 
-        const elapsedTime = endTime - entry.startTime;
-        entry.totalTime += elapsedTime;
-        entry.calls += 1;
-        entry.avgTime = entry.totalTime / entry.calls;
-        entry.startTime = 0;
-        entry.lastElapsedTime = elapsedTime;
-    }
+		const elapsedTime = endTime - entry.startTime;
+		entry.totalTime += elapsedTime;
+		entry.calls += 1;
+		entry.avgTime = entry.totalTime / entry.calls;
+		entry.startTime = 0;
+		entry.lastElapsedTime = elapsedTime;
+	}
 
-    /**
-     * @param {string} counterName
-     */
-    static count(counterName) {
-        if (!this.counter[counterName]) {
-            this.counter[counterName] = 0;
-        }
-        this.counter[counterName] += 1;
-    }
+	/**
+	 * @param {string} counterName
+	 */
+	static count(counterName) {
+		if (!this.counter[counterName]) {
+			this.counter[counterName] = 0;
+		}
+		this.counter[counterName] += 1;
+	}
 
-    static print() {
-        console.log(this.metrics);
-        if (Object.entries(this.counter).length) {
-            console.log(this.counter);
-        }
-    }
+	static print() {
+		console.log(this.metrics);
+		if (Object.entries(this.counter).length) {
+			console.log(this.counter);
+		}
+	}
 
-    /**
-     * @type {number | null}
-     */
-    static schedule = null;
+	/**
+	 * @type {number | null}
+	 */
+	static schedule = null;
 
-    static scheduledPrint() {
-        if (this.schedule !== null) {
-            return;
-        }
-        this.schedule = setInterval(() => {
-            this.print();
-        }, 1000);
-    }
+	static scheduledPrint() {
+		if (this.schedule !== null) {
+			return;
+		}
+		this.schedule = setInterval(() => {
+			this.print();
+		}, 1000);
+	}
 
-    static unschedule() {
-        if (this.schedule !== null) {
-            clearInterval(this.schedule);
-            this.schedule = null;
-        }
-    }
+	static unschedule() {
+		if (this.schedule !== null) {
+			clearInterval(this.schedule);
+			this.schedule = null;
+		}
+	}
 }


### PR DESCRIPTION
### How we handling floodfill?

We are doing inverted floodfill to fill the captured area. For handling this, we first create a mask that bounds the player's area, and then do the floodfill outside the player's boundary to fill all the points not part of the player's area and then we invert the result to find the player's area. 

### Two kinds of traversals:

The floodfill can be done using a stack based approach(DFS) or a queue based approach(BFS), currently we are using DFS for filling the blocks.

#### DFS & BFS: ([source](https://en.wikipedia.org/wiki/Flood_fill#Moving_the_recursion_into_a_data_structure))
![Wfm_floodfill_animation_stack](https://github.com/user-attachments/assets/da5c0dfa-f1bd-49a5-9a81-7c56ce053b5b) ![Wfm_floodfill_animation_queue](https://github.com/user-attachments/assets/6c9f5aad-f8a5-41a7-b68a-ad5ae3933089)

### Why DFS inefficient for our usecase?

In worst-case scenarios, such as a diagonal path:
![image](https://github.com/user-attachments/assets/0a582074-ea44-4802-b92b-35e083e9eeff)

The player's area inside the boundary is minimal, means the empty area (orangish area) is maximum. Using DFS in this scenario requires managing long chains of nodes on the stack, increasing memory operations significantly. In contrast, BFS uses a queue and processes layer by layer, maintaining better memory locality and reducing memory operations.

Also, Modern CPUs optimize cache memory for frequently accessed cells if they are localized. Hence, for our usecase, BFS is more cache-efficient for shapes with a high perimeter-to-area ratio

For more squaryy the area (lower the perimeter-to-area ratio), DFS will be more efficient as in terms of memory operations as well as cache efficiency.. however the area on which we have to run floodfill is significantly less on such cases (see orangish area in the figure below), hence the advantage of DFS is insignificant.

![image](https://github.com/user-attachments/assets/fbe06d1b-271f-4c63-b558-54ae44957c4e)

### What dino did?

Dino converted the DFS based floodfill to BFS (use a queue instead of stack) to reduce the number of memory operations and utilize the cache locality in average cases. 

Also reduced number of enqueue operations by processing all four neighbors at once instead of enqueuing them individually. 

### Test results:

#### Diagonal Path (high perimeter to area ratio):

![image](https://github.com/user-attachments/assets/9ac22429-96a6-4177-883a-6199499bbd42)

![image](https://github.com/user-attachments/assets/fca39f0d-e4a5-45a3-bd09-e1028283bbf0)

#### Square Land (low perimeter to area ratio):

![image](https://github.com/user-attachments/assets/4962c289-efee-44a4-be12-ba4c2281729b)

#### Average performance:

For most of the cases the floodfill with BFS seems to be 40-100% faster than the DFS based floodfill. But dino also obseved that in some cases (especially the land is toooo smol, DFS is faster, however it's insignificant)..

Dino will add a more detailed test results in the comment after doing a more careful analysis.

### Test environment:

Dino did tests with only just a few dinos playing the game. Dino tried making various kind of complex shapes.

### Future improvements:

Since we have a well defined, closed polygon with no holes inside, the current floodfill may not be required... Dino have found promising preliminary results with a wayyyyy faster method but it's still incomplete and have known bugs that why dino waiting to publish.

BFS floodfill can be improved veryyy much by restricting the area to sub-bounds around newly added trails. Additional minor optimizations (e.g., reducing function calls) may also improve performance, but dino first make sure if the faster approach will work or not, so dino don't have to waste time on BFS.


### Note:

This pull request is intended to demonstrate the test optimization and for you to analyse for pitfalls (dino have smol bren), dino will be happy if you open a new ticket or create a test branch for optimization testing. Dino have altered the global speed, and created a no death world and few more for testing purposes, hence this must be tested on a development environment. dino will open a new pull request with production changes if you find the changes promising.

### Warning:

Do not merge this pull request into the main branch. It is intended for testing in a development environment only.
