### PR TITLE
perf(optimize): redesign floodfill worker

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,10 @@
 {
-	"deno.enable": false
+	"deno.enable": false,
+	"editor.formatOnSave": true,
+	"[typescript]": {
+		"editor.defaultFormatter": "denoland.vscode-deno"
+	},
+	"[javascript]": {
+		"editor.defaultFormatter": "denoland.vscode-deno"
+	},
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,5 @@
 	},
 	"[javascript]": {
 		"editor.defaultFormatter": "denoland.vscode-deno"
-	},
+	}
 }

--- a/client/src/main.js
+++ b/client/src/main.js
@@ -1,7 +1,7 @@
 import "./globals.js";
 import { getSelectedServer, initServerSelection } from "./network/serverSelection.js";
 
-var GLOBAL_SPEED = 0.006;
+var GLOBAL_SPEED = 0.015;
 var VIEWPORT_RADIUS = 30;
 var MAX_ZOOM = 430;
 // var MAX_ZOOM = 10000;
@@ -431,9 +431,9 @@ function addSocketWrapper() {
 			var websocket = new RealWebSocket(url);
 			websocket.binaryType = "arraybuffer";
 
-			this.onclose = function () {};
-			this.onopen = function () {};
-			this.onmessage = function () {};
+			this.onclose = function () { };
+			this.onopen = function () { };
+			this.onmessage = function () { };
 
 			var me = this;
 			websocket.onclose = function () {
@@ -2132,7 +2132,7 @@ function resetAll() {
 		scoreStatTarget =
 		realScoreStat =
 		realScoreStatTarget =
-			25;
+		25;
 	myRankSent = false;
 	totalPlayers = 0;
 	playingAndReady = false;
@@ -2320,7 +2320,7 @@ function initVideoAdsScript() {
 					console.log("Ad: " + AD_TYPE + " Completed");
 					onAdFinish();
 				},
-				AIP_REMOVE: function () {},
+				AIP_REMOVE: function () { },
 			});
 		});
 	}
@@ -2482,7 +2482,7 @@ function popUp(url, w, h) {
 		url,
 		"_blank",
 		"toolbar=no, location=no, directories=no, status=no, menubar=no, scrollbars=no, resizable=no, copyhistory=no, width=" +
-			w + ", height=" + h + ", top=" + top + ", left=" + left,
+		w + ", height=" + h + ", top=" + top + ", left=" + left,
 	);
 }
 
@@ -2877,7 +2877,7 @@ function checkPatreonQuery() {
 				setPatreonOverlay(true, "Logging in with patreon...");
 				simpleRequest(
 					"https://patreon.splix.io/login2.php?code=" + query.code + "&redirectUri=" +
-						encodeURIComponent(getPatreonRedirectUri()),
+					encodeURIComponent(getPatreonRedirectUri()),
 					function (data) {
 						lsSet("patreonDeviceId", data);
 						requestPatreonPledgeData(true);
@@ -5605,8 +5605,8 @@ function Utf8ArrayToStr(array) {
 				char3 = array[i++];
 				out += String.fromCharCode(
 					((c & 0x0F) << 12) |
-						((char2 & 0x3F) << 6) |
-						((char3 & 0x3F) << 0),
+					((char2 & 0x3F) << 6) |
+					((char3 & 0x3F) << 0),
 				);
 				break;
 		}

--- a/client/src/main.js
+++ b/client/src/main.js
@@ -431,9 +431,9 @@ function addSocketWrapper() {
 			var websocket = new RealWebSocket(url);
 			websocket.binaryType = "arraybuffer";
 
-			this.onclose = function () { };
-			this.onopen = function () { };
-			this.onmessage = function () { };
+			this.onclose = function () {};
+			this.onopen = function () {};
+			this.onmessage = function () {};
 
 			var me = this;
 			websocket.onclose = function () {
@@ -2132,7 +2132,7 @@ function resetAll() {
 		scoreStatTarget =
 		realScoreStat =
 		realScoreStatTarget =
-		25;
+			25;
 	myRankSent = false;
 	totalPlayers = 0;
 	playingAndReady = false;
@@ -2320,7 +2320,7 @@ function initVideoAdsScript() {
 					console.log("Ad: " + AD_TYPE + " Completed");
 					onAdFinish();
 				},
-				AIP_REMOVE: function () { },
+				AIP_REMOVE: function () {},
 			});
 		});
 	}
@@ -2482,7 +2482,7 @@ function popUp(url, w, h) {
 		url,
 		"_blank",
 		"toolbar=no, location=no, directories=no, status=no, menubar=no, scrollbars=no, resizable=no, copyhistory=no, width=" +
-		w + ", height=" + h + ", top=" + top + ", left=" + left,
+			w + ", height=" + h + ", top=" + top + ", left=" + left,
 	);
 }
 
@@ -2877,7 +2877,7 @@ function checkPatreonQuery() {
 				setPatreonOverlay(true, "Logging in with patreon...");
 				simpleRequest(
 					"https://patreon.splix.io/login2.php?code=" + query.code + "&redirectUri=" +
-					encodeURIComponent(getPatreonRedirectUri()),
+						encodeURIComponent(getPatreonRedirectUri()),
 					function (data) {
 						lsSet("patreonDeviceId", data);
 						requestPatreonPledgeData(true);
@@ -5605,8 +5605,8 @@ function Utf8ArrayToStr(array) {
 				char3 = array[i++];
 				out += String.fromCharCode(
 					((c & 0x0F) << 12) |
-					((char2 & 0x3F) << 6) |
-					((char3 & 0x3F) << 0),
+						((char2 & 0x3F) << 6) |
+						((char3 & 0x3F) << 0),
 				);
 				break;
 		}

--- a/gameServer/src/config.js
+++ b/gameServer/src/config.js
@@ -29,7 +29,7 @@ export const PLAYER_SPAWN_RADIUS = 2;
 /**
  * How many tiles players move per millisecond. This should be the same value as on the client.
  */
-export const PLAYER_TRAVEL_SPEED = 0.006;
+export const PLAYER_TRAVEL_SPEED = 0.015;
 
 /**
  * Time in milliseconds that we allow the player to undo events.

--- a/gameServer/src/gameplay/Arena.js
+++ b/gameServer/src/gameplay/Arena.js
@@ -129,7 +129,7 @@ export class Arena {
 	/**
 	 * Finds unfilled areas of the player and fills them.
 	 * @param {number} playerId
- 	 * @param {[x: number, y: number][]} vertices
+	 * @param {[x: number, y: number][]} vertices
 	 * @param {Vec2[]} otherPlayerLocations
 	 */
 	updateCapturedArea(playerId, vertices, otherPlayerLocations) {

--- a/gameServer/src/gameplay/Arena.js
+++ b/gameServer/src/gameplay/Arena.js
@@ -129,10 +129,15 @@ export class Arena {
 	/**
 	 * Finds unfilled areas of the player and fills them.
 	 * @param {number} playerId
+ 	 * @param {[x: number, y: number][]} vertices
 	 * @param {Vec2[]} otherPlayerLocations
 	 */
-	updateCapturedArea(playerId, otherPlayerLocations) {
-		return this.#messenger.send.updateCapturedArea(playerId, otherPlayerLocations.map((v) => v.toArray()));
+	updateCapturedArea(playerId, vertices, otherPlayerLocations) {
+		return this.#messenger.send.updateCapturedArea(
+			playerId,
+			vertices,
+			otherPlayerLocations.map((v) => v.toArray()),
+		);
 	}
 
 	/**

--- a/gameServer/src/gameplay/Game.js
+++ b/gameServer/src/gameplay/Game.js
@@ -137,8 +137,10 @@ export class Game {
 	 */
 	getNewSpawnPosition() {
 		const position = new Vec2(
-			Math.floor(lerp(PLAYER_SPAWN_RADIUS + 1, this.arena.width - PLAYER_SPAWN_RADIUS - 1, Math.random())),
-			Math.floor(lerp(PLAYER_SPAWN_RADIUS + 1, this.arena.height - PLAYER_SPAWN_RADIUS - 1, Math.random())),
+			4,
+			4,
+			// Math.floor(lerp(PLAYER_SPAWN_RADIUS + 1, this.arena.width - PLAYER_SPAWN_RADIUS - 1, Math.random())),
+			// Math.floor(lerp(PLAYER_SPAWN_RADIUS + 1, this.arena.height - PLAYER_SPAWN_RADIUS - 1, Math.random())),
 		);
 		/** @type {{direction: import("./Player.js").UnpausedDirection, distance: number}[]} */
 		const wallDistances = [

--- a/gameServer/src/gameplay/Game.js
+++ b/gameServer/src/gameplay/Game.js
@@ -137,8 +137,8 @@ export class Game {
 	 */
 	getNewSpawnPosition() {
 		const position = new Vec2(
-			4,
-			4,
+			40,
+			40,
 			// Math.floor(lerp(PLAYER_SPAWN_RADIUS + 1, this.arena.width - PLAYER_SPAWN_RADIUS - 1, Math.random())),
 			// Math.floor(lerp(PLAYER_SPAWN_RADIUS + 1, this.arena.height - PLAYER_SPAWN_RADIUS - 1, Math.random())),
 		);

--- a/gameServer/src/gameplay/Game.js
+++ b/gameServer/src/gameplay/Game.js
@@ -137,8 +137,8 @@ export class Game {
 	 */
 	getNewSpawnPosition() {
 		const position = new Vec2(
-			40,
-			40,
+			4,
+			4,
 			// Math.floor(lerp(PLAYER_SPAWN_RADIUS + 1, this.arena.width - PLAYER_SPAWN_RADIUS - 1, Math.random())),
 			// Math.floor(lerp(PLAYER_SPAWN_RADIUS + 1, this.arena.height - PLAYER_SPAWN_RADIUS - 1, Math.random())),
 		);

--- a/gameServer/src/gameplay/Player.js
+++ b/gameServer/src/gameplay/Player.js
@@ -1005,7 +1005,7 @@ export class Player {
 					throw new Error("Assertion failed, player tiles have already been removed from the arena.");
 				}
 				this.game.arena.fillPlayerTrail(this.#trailVertices, this.id);
-				this.#updateCapturedArea();
+				this.#updateCapturedArea(this.#trailVertices);
 				this.game.broadcastPlayerEmptyTrail(this);
 				this.#clearTrailVertices();
 			}
@@ -1014,9 +1014,13 @@ export class Player {
 		}
 	}
 
-	async #updateCapturedArea() {
+	/**
+	 * @param {Vec2[]} vertices
+	 */
+	async #updateCapturedArea(vertices) {
 		const totalFilledTileCount = await this.game.arena.updateCapturedArea(
 			this.id,
+			vertices.map((v) => v.toArray()),
 			Array.from(this.game.getUnfillableLocations(this)),
 		);
 		this.#setCapturedTileCount(totalFilledTileCount);

--- a/gameServer/src/gameplay/arenaWorker/dinoCapturedArea.js
+++ b/gameServer/src/gameplay/arenaWorker/dinoCapturedArea.js
@@ -21,6 +21,7 @@ export function dinoInitializeMask(width, height) {
 
 const EMPTY_BLOCK = 0;
 const PLAYER_BLOCK = 1;
+const PLAYER_TRAIL = 9;
 
 /**
  * @param {number[][]} arenaTiles
@@ -36,8 +37,6 @@ export function dinoCapturedArea(arenaTiles, playerId, bounds, vertices, unfilla
 	bounds.min.subScalar(1);
 	bounds.max.addScalar(1);
 
-	console.log("vertices", vertices)
-
 	// generate mask
 	for (let i = bounds.min.x; i < bounds.max.x; i++) {
 		const offset = i * lineWidth;
@@ -50,9 +49,45 @@ export function dinoCapturedArea(arenaTiles, playerId, bounds, vertices, unfilla
 		}
 	}
 
+	// fill the trail vertices on the mask
+	fillPlayerTrail(vertices, PLAYER_TRAIL);
+
 	// print mask
 	printer();
 }
+
+
+/** 
+ * @param {[x: number, y: number][]} vertices
+ * @param {number} value
+ */
+function fillPlayerTrail(vertices, value) {
+		if (vertices.length === 1) {
+			const vertex = vertices[0];
+			$matrix(vertex[0] ,vertex[1],value);
+		}
+		for (let i = 0; i < vertices.length - 1; i++) {
+			const vertexA = vertices[i];
+			const vertexB = vertices[i + 1];
+			if (vertexA[0] != vertexB[0] && vertexA[1] != vertexB[1]) {
+				throw new Error("Assertion failed, tried to fill a player trail with a diagonal edge.");
+			}
+
+			// Sort the two corners so that `min` is always in the top left.
+			const minX = Math.min(vertexA[0], vertexB[0]);
+			const minY = Math.min(vertexA[1], vertexB[1]);
+			const maxX = Math.max(vertexA[0], vertexB[0]) + 1;
+			const maxY = Math.max(vertexA[1], vertexB[1]) + 1;
+
+			for(let x = minX; x < maxX; x++){
+				for(let y = minY; y < maxY; y++){
+					$matrix(x,y,value);
+				}
+			}
+		}
+}
+
+
 
 function printer() {
 	for (let j = $bounds.min.y; j < $bounds.max.y; j++) {
@@ -62,6 +97,8 @@ function printer() {
 				line += "  ";
 			} else if ($matrix(i, j) == PLAYER_BLOCK) {
 				line += "██";
+			} else if ($matrix(i,j) == PLAYER_TRAIL) {
+				line += "▒▒"
 			}
 		}
 		console.log(line);

--- a/gameServer/src/gameplay/arenaWorker/dinoCapturedArea.js
+++ b/gameServer/src/gameplay/arenaWorker/dinoCapturedArea.js
@@ -26,14 +26,17 @@ const PLAYER_BLOCK = 1;
  * @param {number[][]} arenaTiles
  * @param {number} playerId
  * @param {import("../../util/util.js").Rect} bounds
+ * @param {[x: number, y: number][]} vertices
  * @param {[x: number, y: number][]} unfillableLocations
  */
-export function dinoCapturedArea(arenaTiles, playerId, bounds, unfillableLocations) {
+export function dinoCapturedArea(arenaTiles, playerId, bounds, vertices, unfillableLocations) {
 	$bounds = bounds;
 
 	// dilate bounds
 	bounds.min.subScalar(1);
 	bounds.max.addScalar(1);
+
+	console.log("vertices", vertices)
 
 	// generate mask
 	for (let i = bounds.min.x; i < bounds.max.x; i++) {

--- a/gameServer/src/gameplay/arenaWorker/dinoCapturedArea.js
+++ b/gameServer/src/gameplay/arenaWorker/dinoCapturedArea.js
@@ -89,8 +89,26 @@ export function dinoCapturedArea(arenaTiles, playerId, bounds, vertices, unfilla
 	// floodfill the closed bounds
 	floodfill(closedBounds, unfillableLocations);
 
+	// fullBounds = merge bounds || closed bounds
+	const fullBounds = {
+		min: new Vec2(Math.min(closedBounds.min.x, bounds.min.x), Math.min(closedBounds.min.y, bounds.min.y)),
+		max: new Vec2(Math.max(closedBounds.max.x, bounds.max.x), Math.max(closedBounds.max.y, bounds.max.y)),
+	};
+
+	// pack the blocks that remains unfilled to rectangles
+	const fillRects = compressTiles(closedBounds, (x, y) => {
+		const index = x * lineWidth + y;
+		return !(matrix[index] === FILLED_BLOCK || matrix[index] === PLAYER_TRAIL || matrix[index] === BOUNDARY_SELECTED_PATH);
+	});
+
 	// print mask
 	printer();
+
+	return {
+		fillRects,
+		totalFilledTileCount: 0, // TODO
+		newBounds: fullBounds,
+	}
 }
 
 

--- a/gameServer/src/gameplay/arenaWorker/dinoCapturedArea.js
+++ b/gameServer/src/gameplay/arenaWorker/dinoCapturedArea.js
@@ -51,14 +51,12 @@ export function dinoCapturedArea(arenaTiles, playerId, bounds, vertices, unfilla
 	$bounds.min.subScalar(1);
 	$bounds.max.addScalar(1);
 
-	// TODO: trailPath and shortestPath should be set of points
-
 	// fill the trail vertices on the mask
 	const {trailPath, trailBounds} = getTrailPoints(vertices);
 
 	// TEMP
 	for (const point of trailPath) {
-		$matrix(point[0], point[1], PLAYER_TRAIL);
+		matrix[point] = PLAYER_TRAIL;
 	}
 	
 	// find a points at which the trail touches the player's land
@@ -69,7 +67,7 @@ export function dinoCapturedArea(arenaTiles, playerId, bounds, vertices, unfilla
 
 	// TEMP
 	for (const point of shortestPath) {
-		$matrix(point[0], point[1], BOUNDARY_SELECTED_PATH);
+		matrix[point] = BOUNDARY_SELECTED_PATH;
 	}
 
 	// TEMP
@@ -222,7 +220,7 @@ function boundaryWalk(start, end) {
 	/** @type {Set<string>} */
 	const visitedSet = new Set();
 
-	const shortestPath = [];
+	const shortestPath = new Set();
 
 	parentMap[`${start[0]},${start[1]}`] = null;
 
@@ -255,7 +253,7 @@ function boundaryWalk(start, end) {
 				pathBounds.min.y = Math.min(pathBounds.min.y, j);
 				pathBounds.max.x = Math.max(pathBounds.max.x, i + 1);
 				pathBounds.max.y = Math.max(pathBounds.max.y, j + 1);
-				shortestPath.push([i, j]);
+				shortestPath.add(i * lineWidth + j);
 			}
 			break;
 		}
@@ -285,11 +283,11 @@ function getTrailPoints(vertices) {
 		max: new Vec2(-Infinity, -Infinity),
 	};
 
-	const trailPath = [];
+	const trailPath = new Set();
 
 	if (vertices.length === 1) {
 		const vertex = vertices[0];
-		trailPath.push(vertex);
+		trailPath.add(vertex[0] * lineWidth + vertex[1]);
 
 		trailBounds.min.x = Math.min(trailBounds.min.x, vertex[0]);
 		trailBounds.min.y = Math.min(trailBounds.min.y, vertex[1]);
@@ -317,7 +315,7 @@ function getTrailPoints(vertices) {
 
 		for (let x = minX; x < maxX; x++) {
 			for (let y = minY; y < maxY; y++) {
-				trailPath.push([x, y]);
+				trailPath.add(x * lineWidth + y);
 			}
 		}
 	}
@@ -377,7 +375,7 @@ function isInsideArena(i, j) {
 /**
  * @param {number[][]} arenaTiles
  * @param {number} playerId
- * @param {number[][]} trailPath
+ * @param {Set<number>} trailPath
  * @param {number[]} start
  * @param {number[]} end
  */
@@ -401,20 +399,14 @@ function findTouchingPoints(arenaTiles, playerId, trailPath, start, end) {
 		if (
 			isInsideArena(si,sj) &&
 			arenaTiles[si][sj] === playerId &&
-			!trailPath.some(
-				/**@param {number[]} point */
-				(point) => point[0] === si && point[1] === sj
-			)
+			!trailPath.has(si * lineWidth + sj)
 		) {
 			startNeighbors.push([si, sj]);
 		}
 		if (
 			isInsideArena(ei,ej) &&
 			arenaTiles[ei][ej] === playerId &&
-			!trailPath.some(
-				/**@param {number[]} point */
-				(point) => point[0] === ei && point[1] === ej
-			)
+			!trailPath.has(ei * lineWidth + ej)
 		) {
 			endNeighbors.push([ei, ej]);
 		}

--- a/gameServer/src/gameplay/arenaWorker/dinoCapturedArea.js
+++ b/gameServer/src/gameplay/arenaWorker/dinoCapturedArea.js
@@ -54,12 +54,15 @@ export function dinoCapturedArea(arenaTiles, playerId, bounds, vertices, unfilla
 	// bounds.max.x = maskWidth - 2
 	// bounds.max.y = maskHeight - 2
 
+	let totalFilledTileCount = 0;
+
 	// generate mask
 	for (let i = bounds.min.x; i < bounds.max.x; i++) {
 		const offset = i * lineWidth;
 		for (let j = bounds.min.y; j < bounds.max.y; j++) {
 			if (arenaTiles[i][j] == playerId) {
 				matrix[offset + j] = PLAYER_BLOCK;
+				totalFilledTileCount++;
 			} else {
 				matrix[offset + j] = EMPTY_BLOCK;
 			}
@@ -110,16 +113,20 @@ export function dinoCapturedArea(arenaTiles, playerId, bounds, vertices, unfilla
 	// pack the blocks that remains unfilled to rectangles
 	const fillRects = compressTiles(closedBounds, (x, y) => {
 		const index = x * lineWidth + y;
-		return !(
+		const status = !(
 			matrix[index] === FILLED_BLOCK ||
 			matrix[index] === PLAYER_TRAIL ||
 			matrix[index] === BOUNDARY_SELECTED_PATH
 		);
+		if (status) {
+			totalFilledTileCount++;
+		}
+		return status;
 	});
 
 	return {
 		fillRects,
-		totalFilledTileCount: 0, // TODO
+		totalFilledTileCount: totalFilledTileCount,
 		newBounds: fullBounds,
 	};
 }

--- a/gameServer/src/gameplay/arenaWorker/dinoCapturedArea.js
+++ b/gameServer/src/gameplay/arenaWorker/dinoCapturedArea.js
@@ -48,35 +48,41 @@ export function dinoCapturedArea(arenaTiles, playerId, bounds, vertices, unfilla
 	$bounds.max.addScalar(1);
 
 	// fill the trail vertices on the mask
-	const {trailPath, trailBounds} = getTrailPoints(vertices);
+	const { trailPath, trailBounds } = getTrailPoints(vertices);
 
 	// find a points at which the trail touches the player's land
-	const [start, end] = findTouchingPoints(arenaTiles, playerId, trailPath, vertices[0], vertices[vertices.length - 1]);
-	
+	const [start, end] = findTouchingPoints(
+		arenaTiles,
+		playerId,
+		trailPath,
+		vertices[0],
+		vertices[vertices.length - 1],
+	);
+
 	// walk the boundary and find a path
-	const {shortestPath, pathBounds} = boundaryWalk(start, end, playerId, arenaTiles, trailPath);
-	
+	const { shortestPath, pathBounds } = boundaryWalk(start, end, playerId, arenaTiles, trailPath);
+
 	// merge bounds
 	const closedBounds = {
 		min: new Vec2(Math.min(trailBounds.min.x, pathBounds.min.x), Math.min(trailBounds.min.y, pathBounds.min.y)),
 		max: new Vec2(Math.max(trailBounds.max.x, pathBounds.max.x), Math.max(trailBounds.max.y, pathBounds.max.y)),
 	};
-	
+
 	// dilate bounds
 	closedBounds.max.addScalar(1);
 	closedBounds.min.subScalar(1);
-	
+
 	// merge paths
 	const path = new Set([...trailPath, ...shortestPath]);
 
 	// clear the mask
-	for(let i = closedBounds.min.x; i < closedBounds.max.x; i++) {
+	for (let i = closedBounds.min.x; i < closedBounds.max.x; i++) {
 		const offset = i * lineWidth;
-		for(let j = closedBounds.min.y; j < closedBounds.max.y; j++) {
+		for (let j = closedBounds.min.y; j < closedBounds.max.y; j++) {
 			matrix[offset + j] = EMPTY_BLOCK;
 		}
 	}
-	
+
 	// floodfill the closed bounds
 	floodfill(closedBounds, path, unfillableLocations);
 
@@ -260,7 +266,7 @@ function boundaryWalk(start, end, playerId, arenaTiles, trailPath) {
 		}
 	}
 
-	return {shortestPath, pathBounds};
+	return { shortestPath, pathBounds };
 }
 
 /**
@@ -309,7 +315,7 @@ function getTrailPoints(vertices) {
 			}
 		}
 	}
-	return {trailPath, trailBounds};
+	return { trailPath, trailBounds };
 }
 
 /**
@@ -388,14 +394,14 @@ function findTouchingPoints(arenaTiles, playerId, trailPath, start, end) {
 		let ej = end[1] + dir[1];
 
 		if (
-			isInsideArena(si,sj) &&
+			isInsideArena(si, sj) &&
 			arenaTiles[si][sj] === playerId &&
 			!trailPath.has(si * lineWidth + sj)
 		) {
 			startNeighbors.push([si, sj]);
 		}
 		if (
-			isInsideArena(ei,ej) &&
+			isInsideArena(ei, ej) &&
 			arenaTiles[ei][ej] === playerId &&
 			!trailPath.has(ei * lineWidth + ej)
 		) {

--- a/gameServer/src/gameplay/arenaWorker/dinoCapturedArea.js
+++ b/gameServer/src/gameplay/arenaWorker/dinoCapturedArea.js
@@ -2,8 +2,8 @@ import { Vec2 } from "renda";
 import { compressTiles } from "../../util/util.js";
 import { CircularQueue } from "../../util/CircularQueue.js";
 
-let maskWidth = 0;
-let maskHeight = 0;
+let arenaWidth = 0;
+let arenaHeight = 0;
 let lineWidth = 0;
 
 /** @type {Uint8Array} */
@@ -20,11 +20,11 @@ let $bounds;
  * @param {number} height
  */
 export function dinoInitializeMask(width, height) {
-	maskWidth = width;
-	maskHeight = height;
-	lineWidth = maskHeight;
-	matrix = new Uint8Array(maskWidth * maskHeight);
-	queue = new CircularQueue(maskWidth * maskHeight);
+	arenaWidth = width;
+	arenaHeight = height;
+	lineWidth = arenaHeight;
+	matrix = new Uint8Array(arenaWidth * arenaHeight);
+	queue = new CircularQueue(arenaWidth * arenaHeight);
 }
 
 const EMPTY_BLOCK = 0;
@@ -371,7 +371,7 @@ function getSignalEdge(center) {
  * @returns {boolean}
  */
 function isInsideArena(i, j) {
-	return i >= 0 && i < maskWidth && j >= 0 && j < maskHeight;
+	return i >= 0 && i < arenaWidth && j >= 0 && j < arenaHeight;
 }
 
 /**
@@ -515,7 +515,7 @@ function $matrix(i, j, val = undefined) {
 		return -1;
 	}
 	if (val !== undefined) {
-		matrix[i * maskWidth + j] = val;
+		matrix[i * lineWidth + j] = val;
 	}
-	return matrix[i * maskWidth + j];
+	return matrix[i * lineWidth + j];
 }

--- a/gameServer/src/gameplay/arenaWorker/dinoCapturedArea.js
+++ b/gameServer/src/gameplay/arenaWorker/dinoCapturedArea.js
@@ -1,0 +1,64 @@
+let maskWidth = 0;
+let maskHeight = 0;
+let lineWidth = 0;
+
+/** @type {Uint8Array} */
+let matrix;
+
+/**
+ * @param {number} width
+ * @param {number} height
+ */
+export function dinoInitializeMask(width, height) {
+	maskWidth = width;
+	maskHeight = height;
+	lineWidth = maskHeight;
+	matrix = new Uint8Array(maskWidth * maskHeight);
+}
+
+const EMPTY_BLOCK = 0;
+const PLAYER_BLOCK = 1;
+
+/**
+ * @param {number[][]} arenaTiles
+ * @param {number} playerId
+ * @param {import("../../util/util.js").Rect} bounds
+ * @param {[x: number, y: number][]} unfillableLocations
+ */
+export function dinoCapturedArea(arenaTiles, playerId, bounds, unfillableLocations) {
+	// dilate bounds
+	bounds.min.subScalar(1);
+	bounds.max.addScalar(1);
+
+	// generate mask
+	for (let i = bounds.min.x; i < bounds.max.x; i++) {
+		const offset = i * lineWidth;
+		for (let j = bounds.min.y; j < bounds.max.y; j++) {
+			if (arenaTiles[i][j] == playerId) {
+				matrix[offset + j] = PLAYER_BLOCK;
+			} else {
+				matrix[offset + j] = EMPTY_BLOCK;
+			}
+		}
+	}
+
+	// print mask
+	printer(bounds);
+}
+
+/**
+ * @param {import("../../util/util.js").Rect} bounds
+ */
+function printer(bounds) {
+	for (let j = bounds.min.y; j < bounds.max.y; j++) {
+		let line = "";
+		for (let i = bounds.min.x; i < bounds.max.x; i++) {
+			if (matrix[i * lineWidth + j] == EMPTY_BLOCK) {
+				line += "  ";
+			} else if (matrix[i * lineWidth + j] == PLAYER_BLOCK) {
+				line += "██";
+			}
+		}
+		console.log(line);
+	}
+}

--- a/gameServer/src/gameplay/arenaWorker/dinoCapturedArea.js
+++ b/gameServer/src/gameplay/arenaWorker/dinoCapturedArea.js
@@ -51,12 +51,6 @@ export function dinoCapturedArea(arenaTiles, playerId, bounds, vertices, unfilla
 	$bounds.min.subScalar(1);
 	$bounds.max.addScalar(1);
 
-	// simulate worst case scenario
-	// $bounds.min.x = 0;
-	// $bounds.min.y = 0;
-	// $bounds.max.x = maskHeight;
-	// $bounds.max.y = maskHeight;
-
 	// fill the trail vertices on the mask
 	const trailBounds = fillPlayerTrail(vertices, PLAYER_TRAIL);
 

--- a/gameServer/src/gameplay/arenaWorker/dinoCapturedArea.js
+++ b/gameServer/src/gameplay/arenaWorker/dinoCapturedArea.js
@@ -5,6 +5,9 @@ let lineWidth = 0;
 /** @type {Uint8Array} */
 let matrix;
 
+/** @type {import("../../util/util.js").Rect} */
+let $bounds;
+
 /**
  * @param {number} width
  * @param {number} height
@@ -26,6 +29,8 @@ const PLAYER_BLOCK = 1;
  * @param {[x: number, y: number][]} unfillableLocations
  */
 export function dinoCapturedArea(arenaTiles, playerId, bounds, unfillableLocations) {
+	$bounds = bounds;
+
 	// dilate bounds
 	bounds.min.subScalar(1);
 	bounds.max.addScalar(1);
@@ -43,22 +48,35 @@ export function dinoCapturedArea(arenaTiles, playerId, bounds, unfillableLocatio
 	}
 
 	// print mask
-	printer(bounds);
+	printer();
 }
 
-/**
- * @param {import("../../util/util.js").Rect} bounds
- */
-function printer(bounds) {
-	for (let j = bounds.min.y; j < bounds.max.y; j++) {
+function printer() {
+	for (let j = $bounds.min.y; j < $bounds.max.y; j++) {
 		let line = "";
-		for (let i = bounds.min.x; i < bounds.max.x; i++) {
-			if (matrix[i * lineWidth + j] == EMPTY_BLOCK) {
+		for (let i = $bounds.min.x; i < $bounds.max.x; i++) {
+			if ($matrix(i, j) == EMPTY_BLOCK) {
 				line += "  ";
-			} else if (matrix[i * lineWidth + j] == PLAYER_BLOCK) {
+			} else if ($matrix(i, j) == PLAYER_BLOCK) {
 				line += "██";
 			}
 		}
 		console.log(line);
 	}
+}
+
+/**
+ * @param {number} i
+ * @param {number} j
+ * @param {number | undefined} val
+ * @returns
+ */
+function $matrix(i, j, val = undefined) {
+	if (i < $bounds.min.x || i >= $bounds.max.x || j < $bounds.min.y || j >= $bounds.max.y) {
+		return -1;
+	}
+	if (val !== undefined) {
+		matrix[i * maskWidth + j] = val;
+	}
+	return matrix[i * maskWidth + j];
 }

--- a/gameServer/src/gameplay/arenaWorker/dinoCapturedArea.js
+++ b/gameServer/src/gameplay/arenaWorker/dinoCapturedArea.js
@@ -226,9 +226,9 @@ function getSignalEdge(center) {
 
     const edges = [];
     for (let i = 0; i < ring.length; i++) {
-        if (ring[i].val === EMPTY_BLOCK && ring[(i + 1) % ring.length].val === PLAYER_BLOCK) {
+        if ((ring[i].val === EMPTY_BLOCK || ring[i].val === PLAYER_TRAIL ) && ring[(i + 1) % ring.length].val === PLAYER_BLOCK) {
             edges.push(ring[(i + 1) % ring.length].coord);
-        } else if (ring[i].val === PLAYER_BLOCK && ring[(i + 1) % ring.length].val === EMPTY_BLOCK) {
+        } else if (ring[i].val === PLAYER_BLOCK && (ring[(i + 1) % ring.length].val === EMPTY_BLOCK || ring[(i + 1) % ring.length].val === PLAYER_TRAIL)) {
             edges.push(ring[i].coord);
         }
     }

--- a/gameServer/src/gameplay/arenaWorker/dinoCapturedArea.js
+++ b/gameServer/src/gameplay/arenaWorker/dinoCapturedArea.js
@@ -65,7 +65,7 @@ export function dinoCapturedArea(arenaTiles, playerId, bounds, vertices, unfilla
 
 	// find a points at which the trail touches the player's land
 	const [start, end] = findTouchingPoints(vertices[0], vertices[vertices.length - 1]);
-	
+
 	// walk the boundary and find a path
 	const pathBounds = boundaryWalk(start, end);
 
@@ -74,7 +74,7 @@ export function dinoCapturedArea(arenaTiles, playerId, bounds, vertices, unfilla
 		min: new Vec2(Math.min(trailBounds.min.x, pathBounds.min.x), Math.min(trailBounds.min.y, pathBounds.min.y)),
 		max: new Vec2(Math.max(trailBounds.max.x, pathBounds.max.x), Math.max(trailBounds.max.y, pathBounds.max.y)),
 	};
-	
+
 	// dilate bounds
 	closedBounds.max.addScalar(1);
 	closedBounds.min.subScalar(1);
@@ -85,7 +85,7 @@ export function dinoCapturedArea(arenaTiles, playerId, bounds, vertices, unfilla
 
 	// floodfill the closed bounds
 	floodfill(closedBounds, unfillableLocations);
-	
+
 	// print mask
 	printer();
 
@@ -104,22 +104,25 @@ export function dinoCapturedArea(arenaTiles, playerId, bounds, vertices, unfilla
 	// pack the blocks that remains unfilled to rectangles
 	const fillRects = compressTiles(closedBounds, (x, y) => {
 		const index = x * lineWidth + y;
-		return !(matrix[index] === FILLED_BLOCK || matrix[index] === PLAYER_TRAIL || matrix[index] === BOUNDARY_SELECTED_PATH);
+		return !(
+			matrix[index] === FILLED_BLOCK ||
+			matrix[index] === PLAYER_TRAIL ||
+			matrix[index] === BOUNDARY_SELECTED_PATH
+		);
 	});
 
 	return {
 		fillRects,
 		totalFilledTileCount: 0, // TODO
 		newBounds: fullBounds,
-	}
+	};
 }
-
 
 /**
  * @param {import("../../util/util.js").Rect} closedBounds
  * @param {[x: number, y: number][]} unfillableLocations
  */
-function floodfill(closedBounds, unfillableLocations){
+function floodfill(closedBounds, unfillableLocations) {
 	queue.clear();
 
 	/**
@@ -133,7 +136,14 @@ function floodfill(closedBounds, unfillableLocations){
 		if (x < closedBounds.min.x || y < closedBounds.min.y) return false;
 		if (x >= closedBounds.max.x || y >= closedBounds.max.y) return false;
 
-		if (matrix[index] === FILLED_BLOCK || matrix[index] === PLAYER_TRAIL || matrix[index] === BOUNDARY_SELECTED_PATH) return false;
+		if (
+			matrix[index] === FILLED_BLOCK ||
+			matrix[index] === PLAYER_TRAIL ||
+			matrix[index] === BOUNDARY_SELECTED_PATH
+		) {
+			return false;
+		}
+
 		return true;
 	}
 
@@ -190,13 +200,11 @@ function floodfill(closedBounds, unfillableLocations){
 	}
 }
 
-
 /**
  * @param {number[]} start
  * @param {number[]} end
  */
 function boundaryWalk(start, end) {
-
 	/** @param {import("../../util/util.js").Rect} bounds */
 	const pathBounds = {
 		min: new Vec2(Infinity, Infinity),
@@ -212,7 +220,7 @@ function boundaryWalk(start, end) {
 	parentMap[`${start[0]},${start[1]}`] = null;
 
 	while (queue.length > 0) {
-		const element = queue.shift(); 
+		const element = queue.shift();
 		if (!element) {
 			continue;
 		}
@@ -231,11 +239,11 @@ function boundaryWalk(start, end) {
 
 			let currentKey = `${node[0]},${node[1]}`;
 			while (currentKey) {
-				let [ci, cj] = currentKey.split(',').map(Number);
+				let [ci, cj] = currentKey.split(",").map(Number);
 				path.push([ci, cj]);
-				currentKey = parentMap[currentKey] || '';
+				currentKey = parentMap[currentKey] || "";
 			}
-			for(let [i, j] of path){
+			for (let [i, j] of path) {
 				pathBounds.min.x = Math.min(pathBounds.min.x, i);
 				pathBounds.min.y = Math.min(pathBounds.min.y, j);
 				pathBounds.max.x = Math.max(pathBounds.max.x, i + 1);
@@ -260,116 +268,122 @@ function boundaryWalk(start, end) {
 	return pathBounds;
 }
 
-
-/** 
+/**
  * @param {number[][]} vertices
  * @param {number} value
  */
 function fillPlayerTrail(vertices, value) {
-		/** @param {import("../../util/util.js").Rect} bounds */
-		let trailBounds = {
-			min: new Vec2(Infinity, Infinity),
-			max: new Vec2(-Infinity, -Infinity),
-		};
-		
-		if (vertices.length === 1) {
-			const vertex = vertices[0];
-			$matrix(vertex[0] ,vertex[1],value);
+	/** @param {import("../../util/util.js").Rect} bounds */
+	let trailBounds = {
+		min: new Vec2(Infinity, Infinity),
+		max: new Vec2(-Infinity, -Infinity),
+	};
 
-			trailBounds.min.x = Math.min(trailBounds.min.x, vertex[0]);
-			trailBounds.min.y = Math.min(trailBounds.min.y, vertex[1]);
-			trailBounds.max.x = Math.max(trailBounds.max.x, vertex[0] + 1);
-			trailBounds.max.y = Math.max(trailBounds.max.y, vertex[1] + 1);
+	if (vertices.length === 1) {
+		const vertex = vertices[0];
+		$matrix(vertex[0], vertex[1], value);
+
+		trailBounds.min.x = Math.min(trailBounds.min.x, vertex[0]);
+		trailBounds.min.y = Math.min(trailBounds.min.y, vertex[1]);
+		trailBounds.max.x = Math.max(trailBounds.max.x, vertex[0] + 1);
+		trailBounds.max.y = Math.max(trailBounds.max.y, vertex[1] + 1);
+	}
+
+	for (let i = 0; i < vertices.length - 1; i++) {
+		const vertexA = vertices[i];
+		const vertexB = vertices[i + 1];
+		if (vertexA[0] != vertexB[0] && vertexA[1] != vertexB[1]) {
+			throw new Error("Assertion failed, tried to fill a player trail with a diagonal edge.");
 		}
-		for (let i = 0; i < vertices.length - 1; i++) {
-			const vertexA = vertices[i];
-			const vertexB = vertices[i + 1];
-			if (vertexA[0] != vertexB[0] && vertexA[1] != vertexB[1]) {
-				throw new Error("Assertion failed, tried to fill a player trail with a diagonal edge.");
-			}
 
-			// Sort the two corners so that `min` is always in the top left.
-			const minX = Math.min(vertexA[0], vertexB[0]);
-			const minY = Math.min(vertexA[1], vertexB[1]);
-			const maxX = Math.max(vertexA[0], vertexB[0]) + 1;
-			const maxY = Math.max(vertexA[1], vertexB[1]) + 1;
+		// Sort the two corners so that `min` is always in the top left.
+		const minX = Math.min(vertexA[0], vertexB[0]);
+		const minY = Math.min(vertexA[1], vertexB[1]);
+		const maxX = Math.max(vertexA[0], vertexB[0]) + 1;
+		const maxY = Math.max(vertexA[1], vertexB[1]) + 1;
 
-			trailBounds.min.x = Math.min(trailBounds.min.x, minX);
-			trailBounds.min.y = Math.min(trailBounds.min.y, minY);
-			trailBounds.max.x = Math.max(trailBounds.max.x, maxX);
-			trailBounds.max.y = Math.max(trailBounds.max.y, maxY);
+		trailBounds.min.x = Math.min(trailBounds.min.x, minX);
+		trailBounds.min.y = Math.min(trailBounds.min.y, minY);
+		trailBounds.max.x = Math.max(trailBounds.max.x, maxX);
+		trailBounds.max.y = Math.max(trailBounds.max.y, maxY);
 
-			for(let x = minX; x < maxX; x++){
-				for(let y = minY; y < maxY; y++){
-					$matrix(x,y,value);
-				}
+		for (let x = minX; x < maxX; x++) {
+			for (let y = minY; y < maxY; y++) {
+				$matrix(x, y, value);
 			}
 		}
-		return trailBounds;
+	}
+	return trailBounds;
 }
 
 /**
  * @param {number[]} center
  */
 function getSignalEdge(center) {
-    const directions = [
-        [0, 1],   // right
-        [-1, 1],  // up-right
-        [-1, 0],  // up
-        [-1, -1], // up-left
-        [0, -1],  // left
-        [1, -1],  // down-left
-        [1, 0],   // down
-        [1, 1]    // down-right
-    ];
+	const directions = [
+		[0, 1], // right
+		[-1, 1], // up-right
+		[-1, 0], // up
+		[-1, -1], // up-left
+		[0, -1], // left
+		[1, -1], // down-left
+		[1, 0], // down
+		[1, 1], // down-right
+	];
 
-    const [i, j] = center;
+	const [i, j] = center;
 
-    const ring = [];
-    for (let dir of directions) {
-        let ni = i + dir[0];
-        let nj = j + dir[1];
-        ring.push({ val: $matrix(ni, nj), coord: [ni, nj] });
-    }
+	const ring = [];
+	for (let dir of directions) {
+		let ni = i + dir[0];
+		let nj = j + dir[1];
+		ring.push({ val: $matrix(ni, nj), coord: [ni, nj] });
+	}
 
-    const edges = [];
-    for (let i = 0; i < ring.length; i++) {
-        if ((ring[i].val === EMPTY_BLOCK || ring[i].val === PLAYER_TRAIL ) && ring[(i + 1) % ring.length].val === PLAYER_BLOCK) {
-            edges.push(ring[(i + 1) % ring.length].coord);
-        } else if (ring[i].val === PLAYER_BLOCK && (ring[(i + 1) % ring.length].val === EMPTY_BLOCK || ring[(i + 1) % ring.length].val === PLAYER_TRAIL)) {
-            edges.push(ring[i].coord);
-        }
-    }
-    return edges;
+	const edges = [];
+	for (let i = 0; i < ring.length; i++) {
+		if (
+			(ring[i].val === EMPTY_BLOCK || ring[i].val === PLAYER_TRAIL) &&
+			ring[(i + 1) % ring.length].val === PLAYER_BLOCK
+		) {
+			edges.push(ring[(i + 1) % ring.length].coord);
+		} else if (
+			ring[i].val === PLAYER_BLOCK &&
+			(ring[(i + 1) % ring.length].val === EMPTY_BLOCK || ring[(i + 1) % ring.length].val === PLAYER_TRAIL)
+		) {
+			edges.push(ring[i].coord);
+		}
+	}
+	return edges;
 }
 
 /**
  * @param {number[]} start
  * @param {number[]} end
  */
-function findTouchingPoints(start, end){
+function findTouchingPoints(start, end) {
 	let startTouch;
-	if($matrix(start[0], start[1]+1) === PLAYER_BLOCK){
-		startTouch = [start[0], start[1]+1];
-	} else if ($matrix(start[0], start[1]-1) === PLAYER_BLOCK){
-		startTouch = [start[0], start[1]-1];
-	} else if ($matrix(start[0]+1, start[1]) === PLAYER_BLOCK){
-		startTouch = [start[0]+1, start[1]];
-	} else if ($matrix(start[0]-1, start[1]) === PLAYER_BLOCK){
-		startTouch = [start[0]-1, start[1]];
+	if ($matrix(start[0], start[1] + 1) === PLAYER_BLOCK) {
+		startTouch = [start[0], start[1] + 1];
+	} else if ($matrix(start[0], start[1] - 1) === PLAYER_BLOCK) {
+		startTouch = [start[0], start[1] - 1];
+	} else if ($matrix(start[0] + 1, start[1]) === PLAYER_BLOCK) {
+		startTouch = [start[0] + 1, start[1]];
+	} else if ($matrix(start[0] - 1, start[1]) === PLAYER_BLOCK) {
+		startTouch = [start[0] - 1, start[1]];
 	} else {
 		startTouch = [start[0], start[1]];
 	}
 
 	let endTouch;
-	if($matrix(end[0], end[1]+1) === PLAYER_BLOCK){
-		endTouch = [end[0], end[1]+1];
-	} else if ($matrix(end[0], end[1]-1) === PLAYER_BLOCK){
-		endTouch = [end[0], end[1]-1];
-	} else if ($matrix(end[0]+1, end[1]) === PLAYER_BLOCK){
-		endTouch = [end[0]+1, end[1]];
-	} else if ($matrix(end[0]-1, end[1]) === PLAYER_BLOCK){
-		endTouch = [end[0]-1, end[1]];
+	if ($matrix(end[0], end[1] + 1) === PLAYER_BLOCK) {
+		endTouch = [end[0], end[1] + 1];
+	} else if ($matrix(end[0], end[1] - 1) === PLAYER_BLOCK) {
+		endTouch = [end[0], end[1] - 1];
+	} else if ($matrix(end[0] + 1, end[1]) === PLAYER_BLOCK) {
+		endTouch = [end[0] + 1, end[1]];
+	} else if ($matrix(end[0] - 1, end[1]) === PLAYER_BLOCK) {
+		endTouch = [end[0] - 1, end[1]];
 	} else {
 		endTouch = [end[0], end[1]];
 	}
@@ -378,25 +392,25 @@ function findTouchingPoints(start, end){
 }
 
 function printer() {
-    for (let j = $bounds.min.y; j < $bounds.max.y; j++) {
-        let line = "";
-        for (let i = $bounds.min.x; i < $bounds.max.x; i++) {
-            if ($matrix(i, j) == EMPTY_BLOCK) {
-                line += "\x1b[37m  "; // White
-            } else if ($matrix(i, j) == PLAYER_BLOCK) {
-                line += "\x1b[31m██"; // Red
-            } else if ($matrix(i, j) == PLAYER_TRAIL) {
-                line += "\x1b[33m░░"; // Yellow
-            } else if ($matrix(i, j) == BOUNDARY_VISITED) {
-                line += "\x1b[34m▒▒"; // Blue
-            } else if ($matrix(i, j) == BOUNDARY_SELECTED_PATH) {
+	for (let j = $bounds.min.y; j < $bounds.max.y; j++) {
+		let line = "";
+		for (let i = $bounds.min.x; i < $bounds.max.x; i++) {
+			if ($matrix(i, j) == EMPTY_BLOCK) {
+				line += "\x1b[37m  "; // White
+			} else if ($matrix(i, j) == PLAYER_BLOCK) {
+				line += "\x1b[31m██"; // Red
+			} else if ($matrix(i, j) == PLAYER_TRAIL) {
+				line += "\x1b[33m░░"; // Yellow
+			} else if ($matrix(i, j) == BOUNDARY_VISITED) {
+				line += "\x1b[34m▒▒"; // Blue
+			} else if ($matrix(i, j) == BOUNDARY_SELECTED_PATH) {
 				line += "\x1b[32m▓▓"; // Green
 			} else {
 				line += "\x1b[37m██"; // White
 			}
-        }
-        console.log(line + "\x1b[0m");
-    }
+		}
+		console.log(line + "\x1b[0m");
+	}
 }
 
 /**

--- a/gameServer/src/gameplay/arenaWorker/dinoCapturedArea.js
+++ b/gameServer/src/gameplay/arenaWorker/dinoCapturedArea.js
@@ -48,6 +48,12 @@ export function dinoCapturedArea(arenaTiles, playerId, bounds, vertices, unfilla
 	// bounds.min.subScalar(1);
 	// bounds.max.addScalar(1);
 
+	// simulate worst case scenario
+	// bounds.min.x = 1
+	// bounds.min.y = 1
+	// bounds.max.x = maskWidth - 2
+	// bounds.max.y = maskHeight - 2
+
 	// generate mask
 	for (let i = bounds.min.x; i < bounds.max.x; i++) {
 		const offset = i * lineWidth;
@@ -87,7 +93,7 @@ export function dinoCapturedArea(arenaTiles, playerId, bounds, vertices, unfilla
 	floodfill(closedBounds, unfillableLocations);
 
 	// print mask
-	printer();
+	// printer();
 
 	// erode bounds
 	bounds.min.addScalar(1);

--- a/gameServer/src/gameplay/arenaWorker/dinoCapturedArea.js
+++ b/gameServer/src/gameplay/arenaWorker/dinoCapturedArea.js
@@ -45,8 +45,8 @@ export function dinoCapturedArea(arenaTiles, playerId, bounds, vertices, unfilla
 	$bounds = bounds;
 
 	// dilate bounds
-	bounds.min.subScalar(1);
-	bounds.max.addScalar(1);
+	// bounds.min.subScalar(1);
+	// bounds.max.addScalar(1);
 
 	// generate mask
 	for (let i = bounds.min.x; i < bounds.max.x; i++) {
@@ -88,8 +88,17 @@ export function dinoCapturedArea(arenaTiles, playerId, bounds, vertices, unfilla
 
 	// floodfill the closed bounds
 	floodfill(closedBounds, unfillableLocations);
+	
+	// print mask
+	printer();
 
-	// fullBounds = merge bounds || closed bounds
+	// erode bounds
+	bounds.min.addScalar(1);
+	bounds.max.subScalar(1);
+	closedBounds.min.addScalar(1);
+	closedBounds.max.subScalar(1);
+
+	// merge bounds
 	const fullBounds = {
 		min: new Vec2(Math.min(closedBounds.min.x, bounds.min.x), Math.min(closedBounds.min.y, bounds.min.y)),
 		max: new Vec2(Math.max(closedBounds.max.x, bounds.max.x), Math.max(closedBounds.max.y, bounds.max.y)),
@@ -100,9 +109,6 @@ export function dinoCapturedArea(arenaTiles, playerId, bounds, vertices, unfilla
 		const index = x * lineWidth + y;
 		return !(matrix[index] === FILLED_BLOCK || matrix[index] === PLAYER_TRAIL || matrix[index] === BOUNDARY_SELECTED_PATH);
 	});
-
-	// print mask
-	printer();
 
 	return {
 		fillRects,

--- a/gameServer/src/gameplay/arenaWorker/dinoCapturedArea.js
+++ b/gameServer/src/gameplay/arenaWorker/dinoCapturedArea.js
@@ -61,6 +61,7 @@ export function dinoCapturedArea(arenaTiles, playerId, bounds, vertices, unfilla
 
 	const path = [];
 	const stack = [start];
+	const parentMap = new Map();
 
 	// boundary walk
 	while (stack.length > 0) {
@@ -73,23 +74,37 @@ export function dinoCapturedArea(arenaTiles, playerId, bounds, vertices, unfilla
 		if ($matrix(i, j) === BOUNDARY_VISITED) {
 			continue;
 		}
-	
-		path.push([i, j]);
+
 		$matrix(i, j, BOUNDARY_VISITED);
-	
+
 		// if path found
 		if (i === end[0] && j === end[1]) {
+
+			// get a direct path
+			let backtrackNode = node;
+			while (backtrackNode) {
+				path.push(backtrackNode);
+				backtrackNode = parentMap.get(backtrackNode.toString());
+			}
+
+			// Mark the selected path on the matrix
 			for (let [i, j] of path) {
 				$matrix(i, j, BOUNDARY_SELECTED_PATH);
 			}
 			break;
 		}
-	
-		// TODO: remove redundant path points
-	
-		let edges = getSignalEdge([i, j])
-		stack.push(...edges);
+
+		let edges = getSignalEdge([i, j]);
+		for (let edge of edges) {
+			if (!parentMap.has(edge.toString())) {
+				parentMap.set(edge.toString(), node);
+				stack.push(edge);
+			}
+		}
 	}
+
+	$matrix(start[0], start[1], PLAYER_TRAIL);
+	$matrix(end[0], end[1], PLAYER_TRAIL);
 
 	// print mask
 	printer();

--- a/gameServer/src/gameplay/arenaWorker/dinoCapturedArea.js
+++ b/gameServer/src/gameplay/arenaWorker/dinoCapturedArea.js
@@ -355,33 +355,40 @@ function getSignalEdge(center) {
  * @param {number[]} end
  */
 function findTouchingPoints(start, end) {
-	let startTouch;
-	if ($matrix(start[0], start[1] + 1) === PLAYER_BLOCK) {
-		startTouch = [start[0], start[1] + 1];
-	} else if ($matrix(start[0], start[1] - 1) === PLAYER_BLOCK) {
-		startTouch = [start[0], start[1] - 1];
-	} else if ($matrix(start[0] + 1, start[1]) === PLAYER_BLOCK) {
-		startTouch = [start[0] + 1, start[1]];
-	} else if ($matrix(start[0] - 1, start[1]) === PLAYER_BLOCK) {
-		startTouch = [start[0] - 1, start[1]];
-	} else {
-		startTouch = [start[0], start[1]];
+	let startNeighbors = [];
+	let endNeighbors = [];
+
+	const directions = [
+		[0, 1], // right
+		[-1, 0], // up
+		[0, -1], // left
+		[1, 0], // down
+	];
+
+	for (const dir of directions) {
+		let si = start[0] + dir[0];
+		let sj = start[1] + dir[1];
+		let ei = end[0] + dir[0];
+		let ej = end[1] + dir[1];
+		if ($matrix(si, sj) === PLAYER_BLOCK) {
+			startNeighbors.push([si, sj]);
+		}
+		if ($matrix(ei, ej) === PLAYER_BLOCK) {
+			endNeighbors.push([ei, ej]);
+		}
 	}
 
-	let endTouch;
-	if ($matrix(end[0], end[1] + 1) === PLAYER_BLOCK) {
-		endTouch = [end[0], end[1] + 1];
-	} else if ($matrix(end[0], end[1] - 1) === PLAYER_BLOCK) {
-		endTouch = [end[0], end[1] - 1];
-	} else if ($matrix(end[0] + 1, end[1]) === PLAYER_BLOCK) {
-		endTouch = [end[0] + 1, end[1]];
-	} else if ($matrix(end[0] - 1, end[1]) === PLAYER_BLOCK) {
-		endTouch = [end[0] - 1, end[1]];
-	} else {
-		endTouch = [end[0], end[1]];
+	startNeighbors.push(start);
+
+	for (const startPoint of startNeighbors) {
+		for (const endPoint of endNeighbors) {
+			if (startPoint[0] !== endPoint[0] || startPoint[1] !== endPoint[1]) {
+				return [startPoint, endPoint];
+			}
+		}
 	}
 
-	return [startTouch, endTouch];
+	return [start, end];
 }
 
 /**

--- a/gameServer/src/gameplay/arenaWorker/dinoCapturedArea.js
+++ b/gameServer/src/gameplay/arenaWorker/dinoCapturedArea.js
@@ -63,14 +63,11 @@ export function dinoCapturedArea(arenaTiles, playerId, bounds, vertices, unfilla
 	// fill the trail vertices on the mask
 	const trailBounds = fillPlayerTrail(vertices, PLAYER_TRAIL);
 
+	// find a points at which the trail touches the player's land
+	const [start, end] = findTouchingPoints(vertices[0], vertices[vertices.length - 1]);
+	
 	// walk the boundary and find a path
-	const start = vertices[0];
-	const end = vertices[vertices.length - 1];
-	$matrix(start[0], start[1], PLAYER_BLOCK);
-	$matrix(end[0], end[1], PLAYER_BLOCK);
 	const pathBounds = boundaryWalk(start, end);
-	$matrix(start[0], start[1], PLAYER_TRAIL);
-	$matrix(end[0], end[1], PLAYER_TRAIL);
 
 	// merge bounds
 	const closedBounds = {
@@ -344,6 +341,40 @@ function getSignalEdge(center) {
         }
     }
     return edges;
+}
+
+/**
+ * @param {number[]} start
+ * @param {number[]} end
+ */
+function findTouchingPoints(start, end){
+	let startTouch;
+	if($matrix(start[0], start[1]+1) === PLAYER_BLOCK){
+		startTouch = [start[0], start[1]+1];
+	} else if ($matrix(start[0], start[1]-1) === PLAYER_BLOCK){
+		startTouch = [start[0], start[1]-1];
+	} else if ($matrix(start[0]+1, start[1]) === PLAYER_BLOCK){
+		startTouch = [start[0]+1, start[1]];
+	} else if ($matrix(start[0]-1, start[1]) === PLAYER_BLOCK){
+		startTouch = [start[0]-1, start[1]];
+	} else {
+		startTouch = [start[0], start[1]];
+	}
+
+	let endTouch;
+	if($matrix(end[0], end[1]+1) === PLAYER_BLOCK){
+		endTouch = [end[0], end[1]+1];
+	} else if ($matrix(end[0], end[1]-1) === PLAYER_BLOCK){
+		endTouch = [end[0], end[1]-1];
+	} else if ($matrix(end[0]+1, end[1]) === PLAYER_BLOCK){
+		endTouch = [end[0]+1, end[1]];
+	} else if ($matrix(end[0]-1, end[1]) === PLAYER_BLOCK){
+		endTouch = [end[0]-1, end[1]];
+	} else {
+		endTouch = [end[0], end[1]];
+	}
+
+	return [startTouch, endTouch];
 }
 
 function printer() {

--- a/gameServer/src/gameplay/arenaWorker/mod.js
+++ b/gameServer/src/gameplay/arenaWorker/mod.js
@@ -100,7 +100,7 @@ const arenaWorkerHandlers = {
 			otherPlayerLocations,
 		);
 		Perf.end("updateCapturedArea");
-		
+
 		// erode bounds (because updateCapturedArea dilates the bounds)
 		bounds.min.addScalar(1);
 		bounds.max.subScalar(1);

--- a/gameServer/src/gameplay/arenaWorker/mod.js
+++ b/gameServer/src/gameplay/arenaWorker/mod.js
@@ -93,7 +93,7 @@ const arenaWorkerHandlers = {
 	updateCapturedArea(playerId, vertices, otherPlayerLocations) {
 		const bounds = boundsTracker.getBounds(playerId);
 		Perf.start("updateCapturedArea");
-		 updateCapturedArea(
+		updateCapturedArea(
 			arenaTiles,
 			playerId,
 			bounds,

--- a/gameServer/src/gameplay/arenaWorker/mod.js
+++ b/gameServer/src/gameplay/arenaWorker/mod.js
@@ -93,7 +93,7 @@ const arenaWorkerHandlers = {
 	updateCapturedArea(playerId, vertices, otherPlayerLocations) {
 		const bounds = boundsTracker.getBounds(playerId);
 		Perf.start("updateCapturedArea");
-		const { fillRects, totalFilledTileCount, newBounds } = updateCapturedArea(
+		 updateCapturedArea(
 			arenaTiles,
 			playerId,
 			bounds,
@@ -102,7 +102,7 @@ const arenaWorkerHandlers = {
 		Perf.end("updateCapturedArea");
 
 		Perf.start("dinoCapturedArea");
-		dinoCapturedArea(
+		const { fillRects, totalFilledTileCount, newBounds } = dinoCapturedArea(
 			arenaTiles,
 			playerId,
 			bounds,

--- a/gameServer/src/gameplay/arenaWorker/mod.js
+++ b/gameServer/src/gameplay/arenaWorker/mod.js
@@ -3,8 +3,10 @@ import { compressTiles, createArenaTiles, serializeRect } from "../../util/util.
 import { PLAYER_SPAWN_RADIUS } from "../../config.js";
 import { fillRect } from "../../util/util.js";
 import { initializeMask, updateCapturedArea } from "./updateCapturedArea.js";
+import { dinoCapturedArea, dinoInitializeMask } from "./dinoCapturedArea.js";
 import { PlayerBoundsTracker } from "./PlayerBoundsTracker.js";
 import { getMinimapPart } from "./getMinimapPart.js";
+import { Perf } from "../../util/Perf.js";
 
 /**
  * Stores which tiles have been filled and by which player.
@@ -29,6 +31,7 @@ const arenaWorkerHandlers = {
 		arenaHeight = height;
 		arenaTiles = createArenaTiles(width, height);
 		initializeMask(width, height);
+		dinoInitializeMask(width, height);
 	},
 	/**
 	 * Fills the spawn area tiles around a player.
@@ -88,12 +91,26 @@ const arenaWorkerHandlers = {
 	 */
 	updateCapturedArea(playerId, otherPlayerLocations) {
 		const bounds = boundsTracker.getBounds(playerId);
+		Perf.start("updateCapturedArea");
 		const { fillRects, totalFilledTileCount, newBounds } = updateCapturedArea(
 			arenaTiles,
 			playerId,
 			bounds,
 			otherPlayerLocations,
 		);
+		Perf.end("updateCapturedArea");
+
+		Perf.start("dinoCapturedArea");
+		dinoCapturedArea(
+			arenaTiles,
+			playerId,
+			bounds,
+			otherPlayerLocations,
+		);
+		Perf.end("dinoCapturedArea");
+
+		Perf.print();
+
 		boundsTracker.updateBounds(playerId, newBounds);
 		for (const { rect } of fillRects) {
 			fillTilesRect(rect, playerId);

--- a/gameServer/src/gameplay/arenaWorker/mod.js
+++ b/gameServer/src/gameplay/arenaWorker/mod.js
@@ -87,9 +87,10 @@ const arenaWorkerHandlers = {
 	/**
 	 * Finds unfilled areas of the player and fills them.
 	 * @param {number} playerId
+	 * @param {[x: number, y: number][]} vertices
 	 * @param {[x: number, y: number][]} otherPlayerLocations
 	 */
-	updateCapturedArea(playerId, otherPlayerLocations) {
+	updateCapturedArea(playerId, vertices, otherPlayerLocations) {
 		const bounds = boundsTracker.getBounds(playerId);
 		Perf.start("updateCapturedArea");
 		const { fillRects, totalFilledTileCount, newBounds } = updateCapturedArea(
@@ -105,6 +106,7 @@ const arenaWorkerHandlers = {
 			arenaTiles,
 			playerId,
 			bounds,
+			vertices,
 			otherPlayerLocations,
 		);
 		Perf.end("dinoCapturedArea");

--- a/gameServer/src/gameplay/arenaWorker/mod.js
+++ b/gameServer/src/gameplay/arenaWorker/mod.js
@@ -92,8 +92,15 @@ const arenaWorkerHandlers = {
 	 */
 	updateCapturedArea(playerId, vertices, otherPlayerLocations) {
 		const bounds = boundsTracker.getBounds(playerId);
+
+		// simulate worst case scenario
+		// bounds.min.x = 1;
+		// bounds.min.y = 1;
+		// bounds.max.x = arenaHeight - 1;
+		// bounds.max.y = arenaHeight - 1;
+
 		Perf.start("updateCapturedArea");
-		updateCapturedArea(
+		const tmp = updateCapturedArea(
 			arenaTiles,
 			playerId,
 			bounds,

--- a/gameServer/src/gameplay/arenaWorker/mod.js
+++ b/gameServer/src/gameplay/arenaWorker/mod.js
@@ -100,6 +100,10 @@ const arenaWorkerHandlers = {
 			otherPlayerLocations,
 		);
 		Perf.end("updateCapturedArea");
+		
+		// erode bounds (because updateCapturedArea dilates the bounds)
+		bounds.min.addScalar(1);
+		bounds.max.subScalar(1);
 
 		Perf.start("dinoCapturedArea");
 		const { fillRects, totalFilledTileCount, newBounds } = dinoCapturedArea(


### PR DESCRIPTION
### Objective function

Redesign  the worker `updateCapturedArea`  to minimize the CPU time consumption.

### Achievement

**4500** times faster than the original `updateCapturedArea` in the worst case.

### Why needed?

The existing algorithm run an inverted floodfill outside the boundary of the player's region to detect the enclosed land and declare it as player's land. The algorithm have to re-run through the whole player bound even when the trail is sooo smol.

When the player bound is sufficiently large and the most of the region in the player's bound is empty, the floodfill starts to stress the worker as it have a complexity of O(mn). This eat up all of the cpu time, hence sloww down the worker and make the game lagyyy and lead to what it's called slowfill, where player area is filled very slowly. 

There are players who trigger slowfill intentionally (or unintentionally) by moving in diagonals as it's the largest continuous shape with minimal area with maximal bounds geometrically. (a point at a corner and another point at the opposite corner is the most minimal area with most maximal bounds).

### dino's solution

Instead of floodfilling the whole region, fill the smallest sub-region that needed to be filled.

### The dino algorithm

Let dino be the worker who does the map filling. When kittin touches the land, dino go to the start of kittin's trail and walk through the edge of kittin's land until dino find the end of kittin's trail.  dino always find the shortest path because dino is guided by BFS.

Now the shortest path which dino found + kittin's trail together form a closed loop, dino then go find the bounding box of the loop and does an inverted floodfill to fill the area inside the loop. dino then add the newly filled area + kittin's old area andd declare that all as kittin's new land.  yaaaayyy, kittin happiee :))
<br>

> _red: kittin's land_
> _orange: kittin's trail_
> _green: shortest path dino found_
> _blue: visited by dino during bfs_
> _white: region flooded by the flood_

#### in the beginning:
![image](https://github.com/user-attachments/assets/0da7b41c-5e9e-402c-96b3-1f0be828fb75)

#### after dino walk around the boundary:
![image](https://github.com/user-attachments/assets/5bc21df7-3b19-47bb-a7e8-83ece23b3323)

#### after the great flood:
![image](https://github.com/user-attachments/assets/e26f77a2-28a8-4975-88cf-7c5c107f77d8)

#### what kittin sees:
![image](https://github.com/user-attachments/assets/d83e3499-64cd-4e3c-bfde-9c8b22d66725)


### Test Results 

#### worst case performance (latest revision)

![image](https://github.com/user-attachments/assets/0a82a353-a6fb-4cf3-bef4-223deafa00eb)

The new `dinoCapturedArea` consistently performs upto 4500 times faster than old `updateCapturedArea` (the `updateCapturedArea` before #157) in the worst case scenario. 

#### worst case performance (previous revision)

![image](https://github.com/user-attachments/assets/25318f80-4e7c-4efc-b7b0-1797eddea998)

### How to test?

- Enable the [`printer`](https://github.com/jespertheend/splix/blob/a43f5b33f54a17e836a229b2a55783fc3f1b0c9d/gameServer/src/gameplay/arenaWorker/dinoCapturedArea.js#L428) to visualize the paths dino walked, the selected path and the bounds. Printer will no longer visualize as good after d97bd497d211a5957228448878e80dd29c996f24 as the paths are no longer marked in the mask matrix.
- To simulate the worst case complexity, set the bounds to maximum (uncomment [these lines](https://github.com/jespertheend/splix/blob/a43f5b33f54a17e836a229b2a55783fc3f1b0c9d/gameServer/src/gameplay/arenaWorker/mod.js#L97-L100)).

**Note:** Disable any calls to [`printer`](https://github.com/jespertheend/splix/blob/a43f5b33f54a17e836a229b2a55783fc3f1b0c9d/gameServer/src/gameplay/arenaWorker/dinoCapturedArea.js#L428) while measuring the performance as `console.log` is tooo sloww.