### PR TITLE
Add anti-cheat to prevent flying in game

### DIFF
--- a/gameServer/src/gameplay/Player.js
+++ b/gameServer/src/gameplay/Player.js
@@ -88,6 +88,7 @@ export class Player {
 	 * Or the current direction if the player is not currently paused.
 	 * @type {Exclude<Direction, "paused">}
 	 */
+	// @ts-ignore
 	#lastUnpausedDirection;
 
 	get currentDirection() {


### PR DESCRIPTION
It fixes the second way of flying by adding some trail vertex right after a player spawn in game.

I changed `#lastUnpausedDirection = "up";` to `#lastUnpausedDirection;` because assigning "up" would result in an invalid movement if player would chose to press down right after spawning, they would be stucked.

The reason I didn't include this anti-cheat in the first PR is because I don't think it will even be problematic, players can still use the first method to fly (the one they use in default mode) if they really want to fly. However due to the fact that players spawn paused in arena mode it can increase the chance of players flying if they figure out how it works somehow, which is why I think this fix could still be necessary later.

It's probably fine if some players discover it by accident and have a bit of fun with it, (they can't do much with it) but you can merge in 1 or 2 weeks maybe or earlier if you would receive some complaints about players abusing it.

For effective anti-cheat and completely prevent flying, it should be combined with your anti-cheat from #172 and modify it a bit to force protocol.