### PR TITLE
Bug fix for arena gamemode

### DIFF
--- a/gameServer/src/gameplay/Player.js
+++ b/gameServer/src/gameplay/Player.js
@@ -424,22 +424,26 @@ export class Player {
 				// If so, we modify the last vertex instead of adding a new one.
 				if (lastVertexA.x == lastVertexB.x && lastVertexA.x == pos.x) {
 					if (pos.y >= lastVertexA.y && pos.y <= lastVertexB.y) {
-						throw new Error(
-							`Assertion failed: Attempted to add a trail vertex (${pos}) in between two previous vertices. Full trail: ${
-								this.#trailVertices.join(" ")
-							}`,
-						);
+						if (this.game.gameMode != "arena") {
+							throw new Error(
+								`Assertion failed: Attempted to add a trail vertex (${pos}) in between two previous vertices. Full trail: ${
+									this.#trailVertices.join(" ")
+								}`,
+							);
+						}
 					}
 					lastVertexA.set(pos);
 					return;
 				}
 				if (lastVertexA.y == lastVertexB.y && lastVertexA.y == pos.y) {
 					if (pos.x >= lastVertexA.x && pos.x <= lastVertexB.x) {
-						throw new Error(
-							`Assertion failed: Attempted to add a trail vertex (${pos}) in between two previous vertices. Full trail: ${
-								this.#trailVertices.join(" ")
-							}`,
-						);
+						if (this.game.gameMode != "arena") {
+							throw new Error(
+								`Assertion failed: Attempted to add a trail vertex (${pos}) in between two previous vertices. Full trail: ${
+									this.#trailVertices.join(" ")
+								}`,
+							);
+						}
 					}
 					lastVertexA.set(pos);
 					return;
@@ -657,9 +661,7 @@ export class Player {
 					this.#drainMovementQueue();
 				} catch (e) {
 					console.error(e);
-					if (this.game.gameMode != "arena") {
-						this.#connection.close();
-					}
+					this.#connection.close();
 				}
 			}
 		}


### PR DESCRIPTION
Here is some bug found by Splixcord :

![image](https://github.com/user-attachments/assets/9d136098-21a8-487a-b1ea-83c6b0e4773a)

This is a rare bug mostly done intentionally by players with a modded client or who changed protocol version and are using some script to reverse on their own tail.

Fix : instead of not kicking players, we change it to not throw the 2 errors leading to this.
Because throwing these errors is what allow players to skip one block and make their tails bug like in the screenshot.

It should be safe to just remove these assertions but we first test in arena mode only to get more data before eventually applying the change to all game modes.