### PR TITLE
Restore player count for unofficial servers

### DIFF
--- a/gameServer/src/config.js
+++ b/gameServer/src/config.js
@@ -80,3 +80,18 @@ export const LEADERBOARD_UPDATE_FREQUENCY = 3_000;
  * allowing players to at least get their current progress on the leaderboard.
  */
 export const REQUIRED_PLAYER_COUNT_FOR_GLOBAL_LEADERBOARD = 10;
+
+/**
+ * List of game modes where scores are reported to the global leaderboard.
+ */
+export const GM_REPORT_SCORES = ["default"];
+
+/**
+ * List of game modes where players are allowed to use trail cancel.
+ */
+export const GM_ALLOW_TRAIL_CANCEL = ["arena", "drawing"];
+
+/**
+ * List of game modes where anti-cheat applies (PROTOCOL_VERSION forced to 1).
+ */
+export const GM_APPLY_ANTI_CHEAT = ["arena"];

--- a/gameServer/src/gameplay/Game.js
+++ b/gameServer/src/gameplay/Game.js
@@ -5,6 +5,7 @@ import { Arena } from "./Arena.js";
 import { Player } from "./Player.js";
 import { WebSocketConnection } from "../WebSocketConnection.js";
 import {
+	GM_REPORT_SCORES,
 	LEADERBOARD_UPDATE_FREQUENCY,
 	MINIMAP_PART_UPDATE_FREQUENCY,
 	PLAYER_SPAWN_RADIUS,
@@ -257,7 +258,12 @@ export class Game {
 	 * @param {import("../../../serverManager/src/LeaderboardManager.js").PlayerScoreData} score
 	 */
 	#reportPlayerScore(score) {
-		if (this.#players.size < REQUIRED_PLAYER_COUNT_FOR_GLOBAL_LEADERBOARD) return;
+		if (
+			this.#players.size < REQUIRED_PLAYER_COUNT_FOR_GLOBAL_LEADERBOARD ||
+			!GM_REPORT_SCORES.includes(this.#gameMode)
+		) {
+			return;
+		}
 		this.#onPlayerScoreReportedCbs.forEach((cb) => cb(score));
 	}
 


### PR DESCRIPTION
Currently the only way to prevent scores from unofficial servers to be reported to the global leaderboard is to disable the control socket. The problem with doing this is that it also hides the player count in the server selector menu.

I added some const in config.js where you can chose for which game modes you want scores to be reported to the global leaderboard, so you can enable the control socket again for the unofficial servers and show player count.

I think it fixes #134 as well.

I didn't check if unlisted servers are still reporting player scores to global lb. But if it does, feel free to make these unlisted servers use some game mode which is not included in the GM_REPORT_SCORES array, it should fix #167. I'm not really fan of doing this, I would rather change the if statement in`#reportPlayerScore(score)`from Game.js directly to also detect unlisted servers, but this should work as temp fix if you are worried about players still ranking names there.

Let me know if you prefer more explicit names for const in config.js e.g. like this :
```
const GAME_MODES_WHICH_REPORT_SCORES_TO_GLOBAL_LB
const GAME_MODES_WHICH_ALLOW_TRAIL_CANCEL
const GAME_MODES_WHICH_APPLY_ANTI_CHEAT
```
The reason I already included `GM_ALLOW_TRAIL_CANCEL` and `GM_APPLY_ANTI_CHEAT` in this PR is because I'm worried to have conflicts while merging upcoming PR, so I already prepared the file for these (I'm not used to git and how to avoid conflicts while editing the same line in 2 different PR).

I didn't allow trail cancel in default mode because iirc you were not sure about allowing it there. Also I didn't apply the anti-cheat to default mode because I think you want players to still be able to use OBP. Feel free to change these things how you like it. I added these 3 const to config.js so you can have more control on how you want each mode to work.