### PR TITLE
fix(gs, memory): avoid memory leak caused by player.#inOtherPlayerViewPorts retaining dead players

### DIFF
--- a/gameServer/src/gameplay/Player.js
+++ b/gameServer/src/gameplay/Player.js
@@ -997,6 +997,9 @@ export class Player {
 	removedFromGame() {
 		this.#removedFromGame = true;
 		this.#clearAllMyTiles();
+		for (const player of this.#playersInViewport) {
+			player.#inOtherPlayerViewports.delete(this);
+		}
 		for (const player of this.#inOtherPlayerViewports) {
 			player.#playerRemovedFromViewport(this);
 		}

--- a/gameServer/src/gameplay/Player.js
+++ b/gameServer/src/gameplay/Player.js
@@ -836,13 +836,12 @@ export class Player {
 	 * @param {Player} player
 	 */
 	#playerRemovedFromViewport(player) {
+		if (this.#removedFromGame) return;
 		if (player == this) return;
 		if (!this.#playersInViewport.has(player)) return;
 		this.#playersInViewport.delete(player);
 		player.#inOtherPlayerViewports.delete(this);
-		if (!this.#removedFromGame) {
-			this.#connection.sendRemovePlayer(player.id);
-		}
+		this.#connection.sendRemovePlayer(player.id);
 	}
 
 	#sendRequiredEdgeChunks() {


### PR DESCRIPTION
Fixes #185 
Supersedes #187 

Joe's PR addressed the significant cause of the memory leak by preventing long chain references. However, dead players are still referenced in `player.#inOtherPlayerViewPorts` of other players. This PR ensures all references to a dead player are cleared immediately, preventing leaks from forming, thus supersedes the previous PR.

### Explanation

For the following action flow diagrams, consider 3 objects A, B and C, where A can see B, B can see both A and C, C can see B.

Here is what happens when B is declared dead (it works same for before and after Joe's PR):
<img width="933" height="652" alt="image" src="https://github.com/user-attachments/assets/d4565ed5-acb5-467d-8d9d-15957a7970a7" />

Note that even though B is dead, as `B.#playersInViewport` and it's dual in A and C has been ignored, it can still be accessed from both A and C.

Things gets more interesting when A is also declared dead, here's the action flow diagram of the algorithm before Joe's changes:
<img width="888" height="629" alt="image" src="https://github.com/user-attachments/assets/cd9df1f0-5feb-40d8-97af-479f42f266b2" />
When A dies, the references to A inside B are ignored since B has already been removed from the game. But since C keeps reference to B, B is not cleared from memory, and since B keeps reference to A, A is not cleared either.

This causes long chains of dead player references to be stored in player object. Also each player spread their chain of references to anyone who reaching their viewport as in "i know a player who knows a dead player who knows a dead player,..... and now you know them too". This prevents the references from getting cleared in real game environment. 

In Joe's PR, the algorithm ignores whether the other players are alive or dead, and proceeds to remove dead player references, thus preventing the long chain history from forming:
<img width="899" height="619" alt="image" src="https://github.com/user-attachments/assets/2b9d29ce-0fb4-4917-8b93-24d62b9c191c" />

However, note that C can still be accessed from B, even though it doesn't keep the long history of dead players anymore. C still keeps the first level dead friends of all of those friends of friends... and all the dead players it has ever seen. (so a spectator in the arena may still hold the references to every player who has appeared during its lifetime)

In this PR, instead of processing the references later, all of the references to a player has been immediately removed whenever they dies, here is what happens when B dies:
<img width="877" height="752" alt="image" src="https://github.com/user-attachments/assets/7a3ede28-02ae-4982-aa67-bb7b4e79d45c" />

Since all references to B are removed immediately, it prevents both long reference chains and one-level dead player history. This PR addresses both issues at once, making it safe to revert #187.
