### PR TITLE
Improvements to spectator mode

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -341,7 +341,7 @@
 						class="rank"
 					></span></span>
 			</div>
-			<div id ="spectatorBlock" class="greenBox" style="display: none">
+			<div id="spectatorBlock" class="greenBox" style="display: none">
 				<span>Players: <span id="infoTotalPlayers" class="rank"></span></span>
 				<br>
 				<span>Spectators: <span id="infoTotalSpectators" class="rank"></span></span>

--- a/client/index.html
+++ b/client/index.html
@@ -341,6 +341,11 @@
 						class="rank"
 					></span></span>
 			</div>
+			<div id ="spectatorBlock" class="greenBox" style="display: none">
+				<span>Players: <span id="infoTotalPlayers" class="rank"></span></span>
+				<br>
+				<span>Spectators: <span id="infoTotalSpectators" class="rank"></span></span>
+			</div>
 			<div id="leaderboard" class="greenBox"></div>
 			<div id="miniMap" class="greenBox">
 				<div id="miniMapPlayer"></div>

--- a/client/src/main.js
+++ b/client/src/main.js
@@ -149,7 +149,10 @@ var myScoreElem,
 	myRank = 0,
 	myRankSent = false,
 	totalPlayersElem,
+	infoTotalPlayersElem,
+	infoTotalSpectatorsElem,
 	totalPlayers = 0;
+	totalSpectators = 1;
 var leaderboardElem, leaderboardDivElem, leaderboardHidden = localStorage.leaderboardHidden == "true";
 var spectatorHidden = localStorage.showSpectators == "true";
 var miniMapPlayer,
@@ -238,6 +241,7 @@ var receiveAction = {
 	UNDO_PLAYER_DIE: 22,
 	TEAM_LIFE_COUNT: 23,
 	PLAYER_IS_SPECTATOR: 24,
+	LOBBY_INFO: 25,
 };
 
 var sendAction = {
@@ -966,7 +970,13 @@ function sendSpectatorMode() {
 		spectatorMode = "false";
 	}
 	wsSendMsg(sendAction.SPECTATOR_MODE, spectatorMode);
-	spectatorMode === "true" ? scoreBlock.style.display = "none" : scoreBlock.style.display = "block";
+	if (spectatorMode === "true") {
+		scoreBlock.style.display = "none";
+		spectatorBlock.style.display = "block";
+	} else {
+		scoreBlock.style.display = "block";
+		spectatorBlock.style.display = "none";
+	}
 }
 
 //sends current skin to websocket
@@ -1290,6 +1300,8 @@ window.onload = function () {
 	myKillsElem = document.getElementById("myKills");
 	myRankElem = document.getElementById("myRank");
 	totalPlayersElem = document.getElementById("totalPlayers");
+	infoTotalPlayersElem = document.getElementById("infoTotalPlayers");
+	infoTotalSpectatorsElem = document.getElementById("infoTotalSpectators");
 	leaderboardElem = document.createElement("tbody");
 	var table = document.createElement("table");
 	table.appendChild(leaderboardElem);
@@ -1300,6 +1312,7 @@ window.onload = function () {
 	beginScreen = document.getElementById("beginScreen");
 	playUI = document.getElementById("playUI");
 	uiElems.push(document.getElementById("scoreBlock"));
+	uiElems.push(document.getElementById("spectatorBlock"));
 	uiElems.push(document.getElementById("miniMap"));
 	// closeNotification = document.getElementById("closeNotification");
 	// uiElems.push(closeNotification);
@@ -1829,6 +1842,10 @@ function onMessage(evt) {
 	if (data[0] == receiveAction.MY_RANK) {
 		myRank = bytesToInt(data[1], data[2]);
 		myRankSent = true;
+		updateStats();
+	}
+	if (data[0] == receiveAction.LOBBY_INFO) {
+		totalSpectators = bytesToInt(data[1], data[2]);
 		updateStats();
 	}
 	if (data[0] == receiveAction.LEADERBOARD) {
@@ -2729,6 +2746,8 @@ function updateStats() {
 	}
 	myRankElem.innerHTML = myRank;
 	totalPlayersElem.innerHTML = totalPlayers;
+	infoTotalPlayersElem.innerHTML = totalPlayers;
+	infoTotalSpectatorsElem.innerHTML = totalSpectators;
 }
 
 //draws a trail on a canvas, can be drawn on multiple canvases

--- a/client/src/main.js
+++ b/client/src/main.js
@@ -4367,7 +4367,7 @@ function loop(timeStamp) {
 					}
 				}
 			}
-			if (player.isMyPlayer || !player.isSpectator || localStorage.showSpectators == "true") {
+			if (!player.isSpectator || localStorage.showSpectators == "true") {
 				drawPlayer(ctx, player, timeStamp);
 			}
 		}

--- a/client/src/main.js
+++ b/client/src/main.js
@@ -151,7 +151,7 @@ var myScoreElem,
 	totalPlayersElem,
 	infoTotalPlayersElem,
 	infoTotalSpectatorsElem,
-	totalPlayers = 0;
+	totalPlayers = 0,
 	totalSpectators = 1;
 var leaderboardElem, leaderboardDivElem, leaderboardHidden = localStorage.leaderboardHidden == "true";
 var spectatorHidden = localStorage.showSpectators == "true";

--- a/client/static/style.css
+++ b/client/static/style.css
@@ -171,6 +171,16 @@ body {
 	text-shadow: 1px 1px 3px rgba(0, 0, 0, 0.2);
 }
 
+#spectatorBlock {
+	position: fixed;
+	padding: 4px;
+	left: 10px;
+	bottom: 15px;
+	z-index: 100;
+	font-size: 12px;
+	text-shadow: 1px 1px 3px rgba(0, 0, 0, 0.2);
+}
+
 .scoreRank > td {
 	padding: 0px 5px;
 	max-width: 200px;

--- a/gameServer/src/WebSocketConnection.js
+++ b/gameServer/src/WebSocketConnection.js
@@ -149,6 +149,10 @@ export class WebSocketConnection {
 			UNDO_PLAYER_DIE: 22,
 			TEAM_LIFE_COUNT: 23,
 			PLAYER_IS_SPECTATOR: 24,
+			/**
+			 * Sends lobby-related information to the client.
+			 */
+			LOBBY_INFO: 25,
 		};
 	}
 
@@ -881,6 +885,23 @@ export class WebSocketConnection {
 				cursor += byteArray.byteLength;
 			}
 		}
+
+		return buffer;
+	}
+
+	/**
+	 * @param {number} totalSpectators
+	 */
+	static createLobbyInfoMessage(totalSpectators) {
+		const buffer = new ArrayBuffer(3);
+		const view = new DataView(buffer);
+		let cursor = 0;
+
+		view.setUint8(cursor, WebSocketConnection.SendAction.LOBBY_INFO);
+		cursor++;
+
+		view.setUint16(cursor, totalSpectators, false);
+		cursor += 2;
 
 		return buffer;
 	}

--- a/gameServer/src/config.js
+++ b/gameServer/src/config.js
@@ -78,6 +78,11 @@ export const MINIMAP_PART_UPDATE_FREQUENCY = 250;
 export const LEADERBOARD_UPDATE_FREQUENCY = 3_000;
 
 /**
+ * How often (in milliseconds) lobby info is sent to all players in a game.
+ */
+export const LOBBY_INFO_UPDATE_FREQUENCY = 3_000;
+
+/**
  * If the amount of players in a game is less then this,
  * then scores won't be reported to the global leaderboard.
  * The current scores of all in game players will be reported

--- a/gameServer/src/gameplay/Game.js
+++ b/gameServer/src/gameplay/Game.js
@@ -339,6 +339,7 @@ export class Game {
 		/** @type {[player: Player, score: number][]} */
 		const playerScores = [];
 		for (const player of this.#players.values()) {
+			if (player.isSpectator) continue;
 			if (this.#gameMode != "arena") {
 				playerScores.push([player, player.getTotalScore()]);
 			} else {

--- a/gameServer/src/gameplay/Game.js
+++ b/gameServer/src/gameplay/Game.js
@@ -7,6 +7,7 @@ import { WebSocketConnection } from "../WebSocketConnection.js";
 import {
 	GM_REPORT_SCORES,
 	LEADERBOARD_UPDATE_FREQUENCY,
+	LOBBY_INFO_UPDATE_FREQUENCY,
 	MINIMAP_PART_UPDATE_FREQUENCY,
 	PLAYER_SPAWN_RADIUS,
 	REQUIRED_PLAYER_COUNT_FOR_GLOBAL_LEADERBOARD,
@@ -41,6 +42,7 @@ export class Game {
 	#lastMinimapUpdateTime = 0;
 	#lastMinimapPart = 0;
 	#lastLeaderboardSendTime = 0;
+	#lastLobbyInfoSendTime = 0;
 	/** @type {ArrayBuffer?} */
 	#lastLeaderboardMessage = null;
 
@@ -103,6 +105,11 @@ export class Game {
 		if (now - this.#lastLeaderboardSendTime > LEADERBOARD_UPDATE_FREQUENCY) {
 			this.#lastLeaderboardSendTime = now;
 			this.#sendLeaderboard();
+		}
+
+		if (now - this.#lastLobbyInfoSendTime > LOBBY_INFO_UPDATE_FREQUENCY) {
+			this.#lastLobbyInfoSendTime = now;
+			this.#sendLobbyInfo();
 		}
 	}
 
@@ -369,12 +376,28 @@ export class Game {
 		}
 	}
 
+	#sendLobbyInfo() {
+		const message = WebSocketConnection.createLobbyInfoMessage(this.getSpectatorCount());
+		
+		for (const player of this.#players.values()) {
+			player.connection.send(message);
+		}
+	}
+
 	getPlayerCount() {
 		let playerCount = 0;
 		for (const player of this.#players.values()) {
 			if (!player.isSpectator) playerCount++;
 		}
 		return playerCount;
+	}
+
+	getSpectatorCount() {
+		let spectatorCount = 0;
+		for (const player of this.#players.values()) {
+			if (player.isSpectator) spectatorCount++;
+		}
+		return spectatorCount;
 	}
 
 	/**

--- a/gameServer/src/gameplay/Game.js
+++ b/gameServer/src/gameplay/Game.js
@@ -209,7 +209,7 @@ export class Game {
 	 * @param {Player} player
 	 */
 	removePlayer(player) {
-		if (this.#players.size == REQUIRED_PLAYER_COUNT_FOR_GLOBAL_LEADERBOARD) {
+		if (this.getPlayerCount() == REQUIRED_PLAYER_COUNT_FOR_GLOBAL_LEADERBOARD) {
 			// If the current player count is REQUIRED_PLAYER_COUNT_FOR_GLOBAL_LEADERBOARD,
 			// then once this player is removed scores will no longer be counted.
 			// We want to at least report the current player scores, that way their progress wasn't all for nothing.
@@ -241,7 +241,7 @@ export class Game {
 	}
 
 	#fireOnPlayerCountChange() {
-		this.#onPlayerCountChangeCbs.forEach((cb) => cb(this.#players.size));
+		this.#onPlayerCountChangeCbs.forEach((cb) => cb(this.getPlayerCount()));
 	}
 
 	/** @typedef {(score: import("../../../serverManager/src/LeaderboardManager.js").PlayerScoreData) => void} OnPlayerScoreReportedCallback */
@@ -261,7 +261,7 @@ export class Game {
 	 */
 	#reportPlayerScore(score) {
 		if (
-			this.#players.size < REQUIRED_PLAYER_COUNT_FOR_GLOBAL_LEADERBOARD ||
+			this.getPlayerCount() < REQUIRED_PLAYER_COUNT_FOR_GLOBAL_LEADERBOARD ||
 			!GM_REPORT_SCORES.includes(this.#gameMode)
 		) {
 			return;
@@ -361,7 +361,7 @@ export class Game {
 			return [player.name, score];
 		});
 
-		const message = WebSocketConnection.createLeaderboardMessage(scores, this.#players.size);
+		const message = WebSocketConnection.createLeaderboardMessage(scores, this.getPlayerCount());
 		this.#lastLeaderboardMessage = message;
 
 		for (const player of this.#players.values()) {
@@ -370,7 +370,11 @@ export class Game {
 	}
 
 	getPlayerCount() {
-		return this.#players.size;
+		let playerCount = 0;
+		for (const player of this.#players.values()) {
+			if (!player.isSpectator) playerCount++;
+		}
+		return(playerCount);
 	}
 
 	/**

--- a/gameServer/src/gameplay/Game.js
+++ b/gameServer/src/gameplay/Game.js
@@ -378,7 +378,6 @@ export class Game {
 
 	#sendLobbyInfo() {
 		const message = WebSocketConnection.createLobbyInfoMessage(this.getSpectatorCount());
-		
 		for (const player of this.#players.values()) {
 			player.connection.send(message);
 		}

--- a/gameServer/src/gameplay/Game.js
+++ b/gameServer/src/gameplay/Game.js
@@ -374,7 +374,7 @@ export class Game {
 		for (const player of this.#players.values()) {
 			if (!player.isSpectator) playerCount++;
 		}
-		return(playerCount);
+		return playerCount;
 	}
 
 	/**

--- a/gameServer/src/gameplay/Player.js
+++ b/gameServer/src/gameplay/Player.js
@@ -1156,6 +1156,7 @@ export class Player {
 	}
 
 	#sendMyRank() {
+		if (this.#isSpectator) return;
 		this.#connection.sendMyRank(this.#rank);
 	}
 


### PR DESCRIPTION
Bug fixes:
- Hide spectators from in game leaderboard ✅
- Don't include spectators in the score box showing player rank ✅
- Don't include spectators in the required player count to propagate score to global LB ✅

Improvements:
- Allow spectators to hide their own player if they prefer some "camera experience", (also useful to record video) ✅
(most likely a flag instead of an extra button)
- Display number of spectators in a lobby? ❌
(maybe associate its visibility with the existing toggle visibility button, so players can have an indicator if the toggle showing spectators is on or off)
- Add auto-pause when spectators spawn in game? ❌
- Allow honks for Pelican subscribers? (WC) ❌
- Add a dedicated "spectator" box to replace the score box ✅
(it could contain informations such as number of players, spectators, etc)
- Add possibility to zoom in/out for spectators? ❌
(toggle button, shift key maybe)
- Increase viewport size for spectators? ❌
(it would help to make the game looks more polished while zoomed out)

