### PR TITLE
Add more rewards for Pelican subscribers

### DIFF
--- a/gameServer/src/config.js
+++ b/gameServer/src/config.js
@@ -101,3 +101,4 @@ export const GM_ALLOW_TRAIL_CANCEL = ["arena", "drawing"];
  * of the protocol version that was sent by the client.
  */
 export const GM_FORCE_FLYING_PATCHES = ["arena"];
+// init PR


### PR DESCRIPTION
- Add bronze and silver colors (possibly an other "theme" if silver wouldn't render good enough)
- Add some new patterns
- Allow spectators to honk (and therefore write message using Wrong Chat as well)?
I'm assuming that most subscribers, if not all, playing Splix are using Wrong Chat so it could be an interesting reward for them while still maintaining the game not P2W, not too sure about it tho, just sharing an idea which crossed my mind.
