### PR TITLE
Prevent wall blocks from being captured

### DIFF
--- a/gameServer/src/config.js
+++ b/gameServer/src/config.js
@@ -101,3 +101,4 @@ export const GM_ALLOW_TRAIL_CANCEL = ["arena", "drawing"];
  * of the protocol version that was sent by the client.
  */
 export const GM_FORCE_FLYING_PATCHES = ["arena"];
+// init PR


### PR DESCRIPTION
Currently, wall blocks can be captured and removed, potentially causing players to die due to invisible walls. In arena game mode, the pit can also be completely removed.

Here is some screenshot of the current state of "Drawing" server (top left corner, wall blocks invisible) :

<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/d371e190-548a-41f1-9665-6aa28547f261" />
