### PR TITLE
fix(dev): prevent forgetting deno fmt once and for all

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,10 @@
 {
-	"deno.enable": false
+	"deno.enable": true,
+	"deno.lint": false,
+	"editor.formatOnSave": true,
+	"[css]": { "editor.defaultFormatter": "denoland.vscode-deno" },
+	"[json]": { "editor.defaultFormatter": "denoland.vscode-deno" },
+	"[html]": { "editor.defaultFormatter": "denoland.vscode-deno" },
+	"[javascript]": { "editor.defaultFormatter": "denoland.vscode-deno" },
+	"[typescript]": { "editor.defaultFormatter": "denoland.vscode-deno" }
 }


### PR DESCRIPTION
Add `deno fmt` as default formatter for major languages used in the project as well as enable format on save for vscode as everyone forget deno fmt all time.